### PR TITLE
[TLVB-39] 이벤트 조회 기능 구현

### DIFF
--- a/src/main/java/kdt/prgrms/kazedon/everevent/controller/EventController.java
+++ b/src/main/java/kdt/prgrms/kazedon/everevent/controller/EventController.java
@@ -1,0 +1,27 @@
+package kdt.prgrms.kazedon.everevent.controller;
+
+import kdt.prgrms.kazedon.everevent.domain.event.dto.SimpleEventReadResponse;
+import kdt.prgrms.kazedon.everevent.service.EventService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/")
+public class EventController {
+    private final EventService eventService;
+
+    @GetMapping("events")
+    public ResponseEntity<SimpleEventReadResponse> getEvents(@RequestParam String location,
+                                                             @PageableDefault(size=20, sort="expiredAt", direction = Sort.Direction.DESC) Pageable pageable){
+        return new ResponseEntity<>(
+                eventService.getEventsByLocation(location, pageable),
+                HttpStatus.OK
+        );
+    }
+}

--- a/src/main/java/kdt/prgrms/kazedon/everevent/domain/event/Event.java
+++ b/src/main/java/kdt/prgrms/kazedon/everevent/domain/event/Event.java
@@ -39,21 +39,25 @@ public class Event extends BaseTimeEntity {
   private String description;
 
   @Column(nullable = false)
+  private int maxParticipants;
+
+  @Column(nullable = false)
+  private int participantCount;
+
+  @Column(nullable = false)
   private int likeCount;
 
   @Column(nullable = false)
   private int reviewCount;
 
-  @Column(nullable = false)
-  private int remainingParticipants;
-
   @Builder
-  public Event(Market market, String name, LocalDateTime expiredAt, String description,int remainingParticipants) {
+  public Event(Market market, String name, LocalDateTime expiredAt, String description,int maxParticipants) {
     this.market = market;
     this.name = name;
     this.expiredAt = expiredAt;
     this.description = description;
-    this.remainingParticipants = remainingParticipants;
+    this.maxParticipants = maxParticipants;
+    this.participantCount = 0;
     this.likeCount = 0;
     this.reviewCount = 0;
   }

--- a/src/main/java/kdt/prgrms/kazedon/everevent/domain/event/dto/SimpleEvent.java
+++ b/src/main/java/kdt/prgrms/kazedon/everevent/domain/event/dto/SimpleEvent.java
@@ -1,0 +1,19 @@
+package kdt.prgrms.kazedon.everevent.domain.event.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+public class SimpleEvent {
+    private Long eventId;
+    private String eventName;
+    private LocalDateTime expiredAt;
+    private String marketName;
+    private int likeCount;
+    private int reviewCount;
+    private boolean isLike;
+    private int remainingParticipants;
+}

--- a/src/main/java/kdt/prgrms/kazedon/everevent/domain/event/dto/SimpleEventReadResponse.java
+++ b/src/main/java/kdt/prgrms/kazedon/everevent/domain/event/dto/SimpleEventReadResponse.java
@@ -1,0 +1,11 @@
+package kdt.prgrms.kazedon.everevent.domain.event.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+import org.springframework.data.domain.Page;
+
+@Getter
+@Builder
+public class SimpleEventReadResponse {
+   private Page<SimpleEvent> simpleEvents;
+}

--- a/src/main/java/kdt/prgrms/kazedon/everevent/domain/event/repository/EventRepository.java
+++ b/src/main/java/kdt/prgrms/kazedon/everevent/domain/event/repository/EventRepository.java
@@ -1,0 +1,15 @@
+package kdt.prgrms.kazedon.everevent.domain.event.repository;
+
+import kdt.prgrms.kazedon.everevent.domain.event.Event;
+import org.springframework.data.domain.Page;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface EventRepository extends JpaRepository<Event, Long> {
+    @Query(value = "SELECT e FROM Event e INNER JOIN e.market m WHERE m.address LIKE %:location%")
+    Page<Event> findByLocation(@Param("location") String location, Pageable pageable);
+}

--- a/src/main/java/kdt/prgrms/kazedon/everevent/exception/GlobalExceptionHandler.java
+++ b/src/main/java/kdt/prgrms/kazedon/everevent/exception/GlobalExceptionHandler.java
@@ -1,0 +1,7 @@
+package kdt.prgrms.kazedon.everevent.exception;
+
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+}

--- a/src/main/java/kdt/prgrms/kazedon/everevent/service/EventService.java
+++ b/src/main/java/kdt/prgrms/kazedon/everevent/service/EventService.java
@@ -1,0 +1,28 @@
+package kdt.prgrms.kazedon.everevent.service;
+
+import kdt.prgrms.kazedon.everevent.domain.event.dto.SimpleEvent;
+import kdt.prgrms.kazedon.everevent.domain.event.dto.SimpleEventReadResponse;
+import kdt.prgrms.kazedon.everevent.domain.event.repository.EventRepository;
+import kdt.prgrms.kazedon.everevent.service.converter.EventConverter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class EventService {
+    private final EventRepository eventRepository;
+    private final EventConverter eventConverter;
+
+    public SimpleEventReadResponse getEventsByLocation(String location, Pageable pageable){
+        Page<SimpleEvent> simpleEvents = eventRepository
+                .findByLocation(location, pageable)
+                .map(event -> eventConverter.convertToSimpleEvent(event, false));
+        //      .filter(condition checking if the user likes this event using [event_like] table)
+
+        return eventConverter.convertToSimpleEventReadResponse(simpleEvents);
+    }
+}

--- a/src/main/java/kdt/prgrms/kazedon/everevent/service/converter/EventConverter.java
+++ b/src/main/java/kdt/prgrms/kazedon/everevent/service/converter/EventConverter.java
@@ -1,0 +1,30 @@
+package kdt.prgrms.kazedon.everevent.service.converter;
+
+import kdt.prgrms.kazedon.everevent.domain.event.Event;
+import kdt.prgrms.kazedon.everevent.domain.event.dto.SimpleEvent;
+import kdt.prgrms.kazedon.everevent.domain.event.dto.SimpleEventReadResponse;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Component;
+
+@Component
+public class EventConverter {
+    public SimpleEventReadResponse convertToSimpleEventReadResponse(Page<SimpleEvent> simpleEvents){
+        return SimpleEventReadResponse.builder()
+                .simpleEvents(simpleEvents)
+                .build();
+    }
+
+    public SimpleEvent convertToSimpleEvent(Event event, boolean isLike){
+        return SimpleEvent.builder()
+                .eventId(event.getId())
+                .eventName(event.getName())
+                .expiredAt(event.getExpiredAt())
+                .marketName(event.getMarket().getName())
+                .likeCount(event.getLikeCount())
+                .reviewCount(event.getReviewCount())
+                .isLike(isLike)
+                .remainingParticipants(event.getMaxParticipants()- event.getParticipantCount())
+                .build();
+    }
+}

--- a/src/test/java/kdt/prgrms/kazedon/everevent/service/EventServiceTest.java
+++ b/src/test/java/kdt/prgrms/kazedon/everevent/service/EventServiceTest.java
@@ -1,0 +1,125 @@
+package kdt.prgrms.kazedon.everevent.service;
+
+import kdt.prgrms.kazedon.everevent.domain.event.Event;
+import kdt.prgrms.kazedon.everevent.domain.event.dto.SimpleEvent;
+import kdt.prgrms.kazedon.everevent.domain.event.dto.SimpleEventReadResponse;
+import kdt.prgrms.kazedon.everevent.domain.event.repository.EventRepository;
+import kdt.prgrms.kazedon.everevent.domain.market.Market;
+import kdt.prgrms.kazedon.everevent.domain.user.User;
+import kdt.prgrms.kazedon.everevent.service.converter.EventConverter;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class EventServiceTest {
+
+    @InjectMocks
+    private EventService eventService;
+
+    @Mock
+    private EventRepository eventRepository;
+
+    @Mock
+    private EventConverter eventConverter;
+
+    @Mock
+    private Pageable pageable;
+
+    private Market market;
+
+    private User user;
+
+    private Event event;
+
+    private Event anotherEvent;
+
+    private SimpleEvent simpleEvent;
+
+    private SimpleEvent anotherSimpleEvent;
+
+    @BeforeEach
+    void setUp() {
+        user = User.builder()
+                .email("test-email")
+                .password("test-password")
+                .nickname("test-nickname")
+                .location("test-location")
+                .build();
+
+        market = Market.builder()
+                .user(user)
+                .name("test-market-name")
+                .description("test-description")
+                .address("test-market-address")
+                .build();
+
+        event = Event.builder()
+                .market(market)
+                .name("test-event-name")
+                .expiredAt(LocalDateTime.now())
+                .description("test-description")
+                .maxParticipants(5)
+                .build();
+
+        anotherEvent = Event.builder()
+                .market(market)
+                .name("another-test-event-name")
+                .expiredAt(LocalDateTime.now().minusDays(2))
+                .description("another-test-description")
+                .maxParticipants(3)
+                .build();
+
+        simpleEvent = SimpleEvent.builder()
+                .eventId(event.getId())
+                .eventName(event.getName())
+                .expiredAt(event.getExpiredAt())
+                .marketName(event.getMarket().getName())
+                .reviewCount(event.getReviewCount())
+                .isLike(false)
+                .remainingParticipants(event.getMaxParticipants() - event.getParticipantCount())
+                .build();
+
+        anotherSimpleEvent = SimpleEvent.builder()
+                .eventId(anotherEvent.getId())
+                .eventName(anotherEvent.getName())
+                .expiredAt(anotherEvent.getExpiredAt())
+                .marketName(anotherEvent.getMarket().getName())
+                .reviewCount(anotherEvent.getReviewCount())
+                .isLike(false)
+                .remainingParticipants(anotherEvent.getMaxParticipants() - anotherEvent.getParticipantCount())
+                .build();
+    }
+
+    @Test
+    void getEventsByLocation() {
+        //Given
+        Page<Event> events = new PageImpl<>(List.of(event, anotherEvent));
+        String location = "test-location";
+
+        when(eventRepository.findByLocation(location, pageable)).thenReturn(events);
+        when(eventConverter.convertToSimpleEvent(event, false)).thenReturn(simpleEvent);
+        when(eventConverter.convertToSimpleEvent(anotherEvent, false)).thenReturn(anotherSimpleEvent);
+
+        //When
+        SimpleEventReadResponse response = eventService.getEventsByLocation(location, pageable);
+
+        //Then
+        verify(eventRepository).findByLocation(location, pageable);
+        verify(eventConverter).convertToSimpleEvent(event, false);
+        verify(eventConverter).convertToSimpleEvent(anotherEvent, false);
+        verify(eventConverter).convertToSimpleEventReadResponse(any());
+
+    }
+}


### PR DESCRIPTION
## 👩‍💻 요구 사항과 구현 내용
- 월요일 회의 시 같이 공유했던 GlobalExceptionHandler 클래스 추가
- 이벤트 조회 기능 구현(성공 시나리오만 고려)
- 이벤트 조회 Service 메소드의 테스트 코드 작성

## ✅ 피드백 반영사항

## 🤔 PR 포인트 & 궁금한 점
- Controller 에 대한 테스트 코드는 작성했는데, Security 관련 빈 생성할 때 오류가 발생하네요ㅜㅜ 내일 Eddie, Rien과 같이 문제 해결하고, Commit 하겠습니다. (우선 Controller에 대한 테스트는 postman으로 수행했습니다!)

- Event 조회 시, 사용자가 설정한 위치(String)가 가게의 주소(String)와 일치하는 부분이 있으면 해당 이벤트를 조회하도록 하였습니다. 쿼리에서 Like 문을 사용하여 처리했습니다. 이 부분에 대해서는 더 고민할 예정입니다.. 더 좋은 아이디어가 있으면 조언 부탁드립니다!
`@Query(value = "SELECT e FROM Event e INNER JOIN e.market m WHERE m.address LIKE %:location%")`

- 오늘 코어타임 시간에 말씀 드렸던 이벤트 조회 결과 `Page<EventReadRequest>`를 일급 컬렉션 형태로 변경하였습니다.
   - `EventReadRequest` -> `SimpleEvent` : 간단한 Event 정보를 나타내는 Dto 클래스
   - `Page<EventReadRequest>` -> `SimpleEventReadRequest` : Page<SimpleEvent>를 포함하는 Dto 클래스(일급 컬렉션)

## 관련 이슈 
TLVB-39