### PR TITLE
[TLVB-111] 사용자 정보 수정 API 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -40,7 +40,8 @@ dependencies {
     testImplementation 'org.springframework.security:spring-security-test'
     testImplementation 'org.springframework.restdocs:spring-restdocs-mockmvc'
     asciidoctor 'org.springframework.restdocs:spring-restdocs-asciidoctor:2.0.2.RELEASE'
-    implementation 'org.slf4j:slf4j-api:1.7.32'
+    testCompileOnly 'org.projectlombok:lombok'
+    testAnnotationProcessor 'org.projectlombok:lombok'
 }
 
 test {

--- a/src/main/java/kdt/prgrms/kazedon/everevent/controller/UserController.java
+++ b/src/main/java/kdt/prgrms/kazedon/everevent/controller/UserController.java
@@ -8,6 +8,7 @@ import kdt.prgrms.kazedon.everevent.configures.auth.AuthUser;
 import kdt.prgrms.kazedon.everevent.domain.user.User;
 import kdt.prgrms.kazedon.everevent.domain.user.dto.SignUpRequest;
 import kdt.prgrms.kazedon.everevent.domain.user.dto.UserReadResponse;
+import kdt.prgrms.kazedon.everevent.domain.user.dto.UserUpdateRequest;
 import kdt.prgrms.kazedon.everevent.service.UserService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -15,12 +16,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.authentication.AnonymousAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping("/api/v1")
@@ -56,6 +52,12 @@ public class UserController {
   @GetMapping("/members")
   public ResponseEntity<UserReadResponse> getUser(@AuthUser User user){
     return ResponseEntity.ok(userService.getUser(user.getId()));
+  }
+
+  @PutMapping("/members")
+  public ResponseEntity<Void> updateUser(@RequestBody @Valid UserUpdateRequest updateRequest, @AuthUser User user){
+    userService.updateUser(updateRequest, user.getId());
+    return ResponseEntity.ok().build();
   }
 
   public boolean isAuthenticated() {

--- a/src/main/java/kdt/prgrms/kazedon/everevent/domain/user/User.java
+++ b/src/main/java/kdt/prgrms/kazedon/everevent/domain/user/User.java
@@ -21,6 +21,7 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.springframework.security.crypto.password.PasswordEncoder;
 
 @Entity
 @Table(name = "user")
@@ -75,6 +76,15 @@ public class User extends BaseTimeEntity {
     this.location = "";
     this.authority = new ArrayList<>();
     addAuthority(new Authority(this, "ROLE_USER"));
+  }
+
+  public void changePassword(String password, PasswordEncoder passwordEncoder){
+    checkPassword(password);
+    this.password = passwordEncoder.encode(password);
+  }
+
+  public void changeNickname(String nickname){
+    this.nickname = nickname;
   }
 
   private void checkEmail(String email) {

--- a/src/main/java/kdt/prgrms/kazedon/everevent/domain/user/User.java
+++ b/src/main/java/kdt/prgrms/kazedon/everevent/domain/user/User.java
@@ -57,7 +57,6 @@ public class User extends BaseTimeEntity {
   @Builder
   public User(String email, String password, String nickname, String location) {
     checkEmail(email);
-    checkPassword(password);
 
     this.email = email;
     this.password = password;
@@ -66,21 +65,18 @@ public class User extends BaseTimeEntity {
     this.authority = new ArrayList<>();
   }
 
-  public User(SignUpRequest request){
-    checkEmail(request.getEmail());
-    checkPassword(request.getPassword());
-
+  public User(SignUpRequest request, String encodedPassword){
     this.email = request.getEmail();
-    this.password = request.getPassword();
+    this.password = encodedPassword;
     this.nickname = request.getNickname();
     this.location = "";
     this.authority = new ArrayList<>();
+
     addAuthority(new Authority(this, "ROLE_USER"));
   }
 
-  public void changePassword(String password, PasswordEncoder passwordEncoder){
-    checkPassword(password);
-    this.password = passwordEncoder.encode(password);
+  public void changePassword(String password){
+    this.password = password;
   }
 
   public void changeNickname(String nickname){
@@ -94,11 +90,4 @@ public class User extends BaseTimeEntity {
       throw new InvalidUserArgumentException(ErrorMessage.INVALID_EMAIL_FORMAT, email);
     }
   }
-
-  private void checkPassword(String password) {
-    if (password.length() >= 100 || password.isBlank()) {
-      throw new InvalidUserArgumentException(ErrorMessage.INVALID_PASSWORD_FORMAT, password);
-    }
-  }
-
 }

--- a/src/main/java/kdt/prgrms/kazedon/everevent/domain/user/dto/SignUpRequest.java
+++ b/src/main/java/kdt/prgrms/kazedon/everevent/domain/user/dto/SignUpRequest.java
@@ -2,6 +2,8 @@ package kdt.prgrms.kazedon.everevent.domain.user.dto;
 
 import javax.validation.constraints.Email;
 import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.Pattern;
+
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -18,12 +20,9 @@ public class SignUpRequest {
   private String email;
 
   @NotBlank(message = "비밀번호를 작성해주세요.")
+  @Pattern(regexp = "^[a-zA-Z0-9]{6,100}$")
   private String password;
 
   @NotBlank(message = "닉네임을 작성해주세요.")
   private String nickname;
-
-  public void encodingPassword(String encode) {
-    password = encode;
-  }
 }

--- a/src/main/java/kdt/prgrms/kazedon/everevent/domain/user/dto/UserUpdateRequest.java
+++ b/src/main/java/kdt/prgrms/kazedon/everevent/domain/user/dto/UserUpdateRequest.java
@@ -14,11 +14,11 @@ import javax.validation.constraints.Size;
 @NoArgsConstructor
 public class UserUpdateRequest {
     @NotBlank
-    String email;
+    private String email;
 
     @Size(max = 20)
-    String nickname;
+    private String nickname;
 
     @Size(max = 100)
-    String password;
+    private String password;
 }

--- a/src/main/java/kdt/prgrms/kazedon/everevent/domain/user/dto/UserUpdateRequest.java
+++ b/src/main/java/kdt/prgrms/kazedon/everevent/domain/user/dto/UserUpdateRequest.java
@@ -5,7 +5,9 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import javax.validation.constraints.Email;
 import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.Pattern;
 import javax.validation.constraints.Size;
 
 @Getter
@@ -14,11 +16,13 @@ import javax.validation.constraints.Size;
 @NoArgsConstructor
 public class UserUpdateRequest {
     @NotBlank
+    @Email
     private String email;
 
     @Size(max = 20)
     private String nickname;
 
     @Size(max = 100)
+    @Pattern(regexp = "^(?=.*[0-9])(?=.*[a-zA-Z]).{6,100}$")
     private String password;
 }

--- a/src/main/java/kdt/prgrms/kazedon/everevent/domain/user/dto/UserUpdateRequest.java
+++ b/src/main/java/kdt/prgrms/kazedon/everevent/domain/user/dto/UserUpdateRequest.java
@@ -23,6 +23,6 @@ public class UserUpdateRequest {
     private String nickname;
 
     @Size(max = 100)
-    @Pattern(regexp = "^(?=.*[0-9])(?=.*[a-zA-Z]).{6,100}$")
+    @Pattern(regexp = "^[a-zA-Z0-9]{6,100}$")
     private String password;
 }

--- a/src/main/java/kdt/prgrms/kazedon/everevent/domain/user/dto/UserUpdateRequest.java
+++ b/src/main/java/kdt/prgrms/kazedon/everevent/domain/user/dto/UserUpdateRequest.java
@@ -1,0 +1,24 @@
+package kdt.prgrms.kazedon.everevent.domain.user.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.Size;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class UserUpdateRequest {
+    @NotBlank
+    String email;
+
+    @Size(max = 20)
+    String nickname;
+
+    @Size(max = 100)
+    String password;
+}

--- a/src/main/java/kdt/prgrms/kazedon/everevent/domain/user/repository/UserRepository.java
+++ b/src/main/java/kdt/prgrms/kazedon/everevent/domain/user/repository/UserRepository.java
@@ -4,6 +4,7 @@ import java.util.Optional;
 import kdt.prgrms.kazedon.everevent.domain.user.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 @Repository
@@ -12,8 +13,8 @@ public interface UserRepository extends JpaRepository<User, Long> {
   Optional<User> findByEmail(String email);
 
   @Query("select (count(u) > 0) from User u where u.email = :email")
-  boolean existsByEmail(String email);
+  boolean existsByEmail(@Param("email") String email);
 
   @Query("select (count(u) > 0) from User u where u.nickname = :nickname")
-  boolean existsByNickname(String nickname);
+  boolean existsByNickname(@Param("nickname") String nickname);
 }

--- a/src/main/java/kdt/prgrms/kazedon/everevent/domain/user/repository/UserRepository.java
+++ b/src/main/java/kdt/prgrms/kazedon/everevent/domain/user/repository/UserRepository.java
@@ -12,9 +12,7 @@ public interface UserRepository extends JpaRepository<User, Long> {
 
   Optional<User> findByEmail(String email);
 
-  @Query("select (count(u) > 0) from User u where u.email = :email")
-  boolean existsByEmail(@Param("email") String email);
+  boolean existsByEmail(String email);
 
-  @Query("select (count(u) > 0) from User u where u.nickname = :nickname")
-  boolean existsByNickname(@Param("nickname") String nickname);
+  boolean existsByNickname(String nickname);
 }

--- a/src/main/java/kdt/prgrms/kazedon/everevent/exception/ErrorMessage.java
+++ b/src/main/java/kdt/prgrms/kazedon/everevent/exception/ErrorMessage.java
@@ -7,7 +7,7 @@ public enum ErrorMessage {
   DUPLICATE_FAVORITE_MARKET("아이디 {0}은 이미 존재하는 즐겨찾기 항목입니다."),
   DUPLICATE_NOT_FAVORITE_MARKET("아이디 {0}은 이미 삭제한 즐겨찾기 항목입니다."),
   INVALID_EMAIL_FORMAT("이메일 {0}은 잘못된 형식입니다."),
-  INVALID_PASSWORD_FORMAT("비밀번호 {0}은 잘못된 형식입니다."),
+  INVALID_PASSWORD_FORMAT("비밀번호는 1자 이상 100자 이하로 입력되어야 합니다."),
   DUPLICATE_NICKNAME_ARGUMENT("닉네임 {0}은 이미 존재하는 닉네임입니다."),
   DUPLICATE_EMAIL_ARGUMENT("이메일 {0}은 이미 존재하는 이메일입니다."),
   FAVORITE_NOT_FOUNDED("즐겨찾기 {0}은 존재하지 않는 항목입니다."),

--- a/src/main/java/kdt/prgrms/kazedon/everevent/exception/ErrorMessage.java
+++ b/src/main/java/kdt/prgrms/kazedon/everevent/exception/ErrorMessage.java
@@ -7,7 +7,6 @@ public enum ErrorMessage {
   DUPLICATE_FAVORITE_MARKET("아이디 {0}은 이미 존재하는 즐겨찾기 항목입니다."),
   DUPLICATE_NOT_FAVORITE_MARKET("아이디 {0}은 이미 삭제한 즐겨찾기 항목입니다."),
   INVALID_EMAIL_FORMAT("이메일 {0}은 잘못된 형식입니다."),
-  INVALID_PASSWORD_FORMAT("비밀번호는 1자 이상 100자 이하로 입력되어야 합니다."),
   DUPLICATE_NICKNAME_ARGUMENT("닉네임 {0}은 이미 존재하는 닉네임입니다."),
   DUPLICATE_EMAIL_ARGUMENT("이메일 {0}은 이미 존재하는 이메일입니다."),
   FAVORITE_NOT_FOUNDED("즐겨찾기 {0}은 존재하지 않는 항목입니다."),

--- a/src/main/java/kdt/prgrms/kazedon/everevent/service/UserService.java
+++ b/src/main/java/kdt/prgrms/kazedon/everevent/service/UserService.java
@@ -3,6 +3,7 @@ package kdt.prgrms.kazedon.everevent.service;
 import kdt.prgrms.kazedon.everevent.domain.user.User;
 import kdt.prgrms.kazedon.everevent.domain.user.dto.SignUpRequest;
 import kdt.prgrms.kazedon.everevent.domain.user.dto.UserReadResponse;
+import kdt.prgrms.kazedon.everevent.domain.user.dto.UserUpdateRequest;
 import kdt.prgrms.kazedon.everevent.domain.user.repository.UserRepository;
 import kdt.prgrms.kazedon.everevent.exception.DuplicateUserArgumentException;
 import kdt.prgrms.kazedon.everevent.exception.ErrorMessage;
@@ -51,5 +52,22 @@ public class UserService {
             .orElseThrow(() -> new NotFoundException(ErrorMessage.USER_NOT_FOUNDED, userId));
 
     return userConverter.convertToUserReadResponse(retrievedUser);
+  }
+
+  @Transactional
+  public Long updateUser(UserUpdateRequest updateRequest, Long userId){
+    User user = userRepository.findById(userId)
+            .orElseThrow(() -> new NotFoundException(ErrorMessage.USER_NOT_FOUNDED, userId));
+
+    if(updateRequest.getPassword() != null){
+      user.changePassword(updateRequest.getPassword(), passwordEncoder);
+    }
+
+    if(updateRequest.getNickname() != null){
+      checkNicknameDuplicate(updateRequest.getNickname());
+      user.changeNickname(updateRequest.getNickname());
+    }
+
+    return userRepository.save(user).getId();
   }
 }

--- a/src/test/java/kdt/prgrms/kazedon/everevent/controller/EventControllerTest.java
+++ b/src/test/java/kdt/prgrms/kazedon/everevent/controller/EventControllerTest.java
@@ -59,10 +59,10 @@ class EventControllerTest {
     private SignUpRequest signUpRequest = SignUpRequest.builder()
             .email("user-email@gmail.com")
             .nickname("user-nickname")
-            .password("$2b$10$ux4JoQBz5AIFWCGh.TdgDuGyOjXpW2oJ3EO7qjbLZ5HTfdynvM34G") //password
+            .password("user-pwd") //password
             .build();
 
-    private User user = new User(signUpRequest);
+    private User user = new User(signUpRequest, "$2b$10$ux4JoQBz5AIFWCGh.TdgDuGyOjXpW2oJ3EO7qjbLZ5HTfdynvM34G");
 
     private String token = jwtAuthenticationProvider().createToken(user.getEmail(), List.of("ROLE_USER"));
 

--- a/src/test/java/kdt/prgrms/kazedon/everevent/controller/MarketControllerTest.java
+++ b/src/test/java/kdt/prgrms/kazedon/everevent/controller/MarketControllerTest.java
@@ -55,10 +55,10 @@ public class MarketControllerTest {
     private SignUpRequest signUpRequest = SignUpRequest.builder()
             .email("user-email5@gmail.com")
             .nickname("user-nickname")
-            .password("$2b$10$ux4JoQBz5AIFWCGh.TdgDuGyOjXpW2oJ3EO7qjbLZ5HTfdynvM34G") //password
+            .password("user-password") //password
             .build();
 
-    private User user = new User(signUpRequest);
+    private User user = new User(signUpRequest, "$2b$10$ux4JoQBz5AIFWCGh.TdgDuGyOjXpW2oJ3EO7qjbLZ5HTfdynvM34G");
 
     private String token = jwtAuthenticationProvider().createToken(user.getEmail(), List.of("ROLE_USER"));
 

--- a/src/test/java/kdt/prgrms/kazedon/everevent/service/UserServiceTest.java
+++ b/src/test/java/kdt/prgrms/kazedon/everevent/service/UserServiceTest.java
@@ -48,15 +48,17 @@ class UserServiceTest {
 
   private String userEmail;
 
+  private String encodedPassword = "$2b$10$ux4JoQBz5AIFWCGh.TdgDuGyOjXpW2oJ3EO7qjbLZ5HTfdynvM34G";
+
   @BeforeEach
   public void setUp(){
     userEmail = "test-user@gmail.com";
     signUpRequest = SignUpRequest.builder()
         .email(userEmail)
         .nickname("user-nickname")
-        .password("$2b$10$ux4JoQBz5AIFWCGh.TdgDuGyOjXpW2oJ3EO7qjbLZ5HTfdynvM34G") //password
+        .password("paaword") //password
         .build();
-    user = new User(signUpRequest);
+    user = new User(signUpRequest, encodedPassword);
     userRepository.save(user);
     ReflectionTestUtils.setField(user, "id", 1L);
   }
@@ -65,12 +67,13 @@ class UserServiceTest {
   void signUp() {
     //Given
     String signupEmail = "test-user2@gmail.com";
+    String encodedPassword2 = "$2b$10$ux4JoQBz5AIFWCGh.TdgDuGyOjXpW2oJ3EO7qjbLZ5HTfdynvM34G";
     SignUpRequest signUpRequest2 = SignUpRequest.builder()
         .email(signupEmail)
         .nickname("user-nickname2")
-        .password("$2b$10$ux4JoQBz5AIFWCGh.TdgDuGyOjXpW2oJ3EO7qjbLZ5HTfdynvM34G") //password
+        .password("new-password")
         .build();
-    User user2 = new User(signUpRequest2);
+    User user2 = new User(signUpRequest2, encodedPassword2);
 
     given(userRepository.save(any())).willReturn(user2);
     given(passwordEncoder.encode(any())).willReturn("password");

--- a/src/test/java/kdt/prgrms/kazedon/everevent/service/UserServiceTest.java
+++ b/src/test/java/kdt/prgrms/kazedon/everevent/service/UserServiceTest.java
@@ -1,21 +1,22 @@
 package kdt.prgrms.kazedon.everevent.service;
 
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.allOf;
-import static org.hamcrest.Matchers.notNullValue;
-import static org.hamcrest.Matchers.samePropertyValuesAs;
+import static org.hamcrest.Matchers.*;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 
 import java.util.Optional;
 import kdt.prgrms.kazedon.everevent.domain.user.User;
 import kdt.prgrms.kazedon.everevent.domain.user.dto.SignUpRequest;
+import kdt.prgrms.kazedon.everevent.domain.user.dto.UserUpdateRequest;
 import kdt.prgrms.kazedon.everevent.domain.user.repository.UserRepository;
+import kdt.prgrms.kazedon.everevent.exception.DuplicateUserArgumentException;
 import kdt.prgrms.kazedon.everevent.exception.NotFoundException;
 import kdt.prgrms.kazedon.everevent.service.converter.UserConverter;
+import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -25,6 +26,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.test.util.ReflectionTestUtils;
 
+@Slf4j
 @ExtendWith(MockitoExtension.class)
 class UserServiceTest {
 
@@ -107,6 +109,131 @@ class UserServiceTest {
     //When
     //Then
     assertThrows(NotFoundException.class, () -> userService.getUser(invalidUserId));
+    verify(userRepository).findById(invalidUserId);
+  }
+
+  @Test
+  void updateUserNickname(){
+    //Given
+    Long userId = 1L;
+    UserUpdateRequest updateRequest = UserUpdateRequest.builder()
+            .nickname("update-user-nickname")
+            .password(null)
+            .build();
+
+    when(userRepository.findById(userId)).thenReturn(Optional.of(user));
+    when(userRepository.existsByNickname(updateRequest.getNickname())).thenReturn(false);
+    when(userRepository.save(user)).thenReturn(user);
+
+    //When
+    userService.updateUser(updateRequest, userId);
+    log.debug("user => nickname : {}, password : {}", user.getNickname(), user.getPassword());
+
+    //Then
+    assertThat(user.getNickname(), is(updateRequest.getNickname()));
+    assertNotNull(user.getPassword());
+
+    verify(userRepository).findById(userId);
+    verify(userRepository).existsByNickname(updateRequest.getNickname());
+    verify(userRepository, times(2)).save(user);
+  }
+
+  @Test
+  void updateUserPassword(){
+    //Given
+    Long userId = 1L;
+    String newEncodedPassword = "$8a$10$ux4JoQBz5AIFWCGh.TdgDuGyOjXpW2oJ3EO7qjbLZ5HTfdynvM34G";
+    UserUpdateRequest updateRequest = UserUpdateRequest.builder()
+            .nickname(null)
+            .password("new-password")
+            .build();
+
+    when(userRepository.findById(userId)).thenReturn(Optional.of(user));
+    when(passwordEncoder.encode(updateRequest.getPassword())).thenReturn(newEncodedPassword);
+    when(userRepository.save(user)).thenReturn(user);
+
+    //When
+    userService.updateUser(updateRequest, userId);
+    log.debug("user => nickname : {}, password : {}", user.getNickname(), user.getPassword());
+
+    //Then
+    assertNotNull(user.getNickname());
+    assertThat(user.getPassword(), is(newEncodedPassword));
+
+    verify(userRepository).findById(userId);
+    verify(passwordEncoder).encode(updateRequest.getPassword());
+    verify(userRepository, times(2)).save(user);
+  }
+
+  @Test
+  void updateUserNicknameAndPassword(){
+    //Given
+    Long userId = 1L;
+    String newEncodedPassword = "$8a$10$ux4JoQBz5AIFWCGh.TdgDuGyOjXpW2oJ3EO7qjbLZ5HTfdynvM34G";
+    UserUpdateRequest updateRequest = UserUpdateRequest.builder()
+            .nickname("new-nickname")
+            .password("new-password")
+            .build();
+
+    when(userRepository.findById(userId)).thenReturn(Optional.of(user));
+    when(userRepository.existsByNickname(updateRequest.getNickname())).thenReturn(false);
+    when(passwordEncoder.encode(updateRequest.getPassword())).thenReturn(newEncodedPassword);
+    when(userRepository.save(user)).thenReturn(user);
+
+    //When
+    userService.updateUser(updateRequest, userId);
+    log.debug("user => nickname : {}, password : {}", user.getNickname(), user.getPassword());
+
+    //Then
+    assertThat(user.getNickname(), is(updateRequest.getNickname()));
+    assertThat(user.getPassword(), is(newEncodedPassword));
+
+    verify(userRepository).findById(userId);
+    verify(userRepository).existsByNickname(updateRequest.getNickname());
+    verify(passwordEncoder).encode(updateRequest.getPassword());
+    verify(userRepository, times(2)).save(user);
+  }
+
+  @Test
+  void updateUserUsingDuplicatedNickname(){
+    //Given
+    Long userId = 1L;
+    String newEncodedPassword = "$8a$10$ux4JoQBz5AIFWCGh.TdgDuGyOjXpW2oJ3EO7qjbLZ5HTfdynvM34G";
+    UserUpdateRequest updateRequest = UserUpdateRequest.builder()
+            .nickname("new-nickname")
+            .password("new-password")
+            .build();
+
+    when(userRepository.findById(userId)).thenReturn(Optional.of(user));
+    when(passwordEncoder.encode(updateRequest.getPassword())).thenReturn(newEncodedPassword);
+    when(userRepository.existsByNickname(updateRequest.getNickname())).thenReturn(true);
+
+    //When
+    assertThrows(DuplicateUserArgumentException.class, () -> userService.updateUser(updateRequest, userId));
+    log.debug("user => nickname : {}, password : {}", user.getNickname(), user.getPassword());
+
+    //Then
+    assertThat(user.getNickname(), not(updateRequest.getNickname()));
+
+    verify(userRepository).findById(userId);
+    verify(passwordEncoder).encode(updateRequest.getPassword());
+    verify(userRepository, times(1)).save(user);
+  }
+
+  @Test
+  void updateNonExistingUser(){
+    //Given
+    Long invalidUserId = Long.MAX_VALUE;
+    UserUpdateRequest updateRequest = UserUpdateRequest.builder()
+            .nickname("new-nickname")
+            .password("new-password")
+            .build();
+
+    when(userRepository.findById(invalidUserId)).thenReturn(Optional.empty());
+
+    //When
+    //Then
+    assertThrows(NotFoundException.class, () -> userService.updateUser(updateRequest, invalidUserId));
     verify(userRepository).findById(invalidUserId);
   }
 }


### PR DESCRIPTION
## 👩‍💻 요구 사항과 구현 내용
사용자 정보 수정 API를 구현했습니다.

사용자 정보는 세가지 경우로 수정할 수 있습니다.

1) 닉네임만 수정
2) 비밀번호만 수정
3) 닉네임과 비밀번호를 같이 수정

## ✅ 피드백 반영사항

## 🤔 PR 포인트 & 궁금한 점

## 관련 이슈 
TLVB-111