### PR TITLE
[TLVB-130] org.h2.util.StringUtils import 버그 수정

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -33,7 +33,7 @@ dependencies {
     implementation 'io.jsonwebtoken:jjwt:0.9.1'
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'
-    runtimeOnly 'com.h2database:h2'
+    implementation 'com.h2database:h2'
     runtimeOnly 'mysql:mysql-connector-java'
     implementation 'org.slf4j:slf4j-api:1.7.32'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'


### PR DESCRIPTION
## 👩‍💻 요구 사항과 구현 내용
- org.h2.util.StringUtils import 버그 수정
- 해당 라이브러리를 사용하기 위해 build.gradle에 'com.h2database:h2'을 runtimeonly에서 implementation으로 변경했었는데 현재 develop 에 runtimeonly로 되어 버그가 발생해 수정하였습니다. 
## ✅ 피드백 반영사항

## 🤔 PR 포인트 & 궁금한 점

## 관련 이슈 
TLVB-125