### PR TITLE
[TLVB-134] 이벤트 리스트 조회 시 사용자의 좋아요, 리뷰 수, 이벤트 참여 수 반영

### DIFF
--- a/src/main/java/kdt/prgrms/kazedon/everevent/controller/EventController.java
+++ b/src/main/java/kdt/prgrms/kazedon/everevent/controller/EventController.java
@@ -42,8 +42,9 @@ public class EventController {
 
     @GetMapping("events")
     public ResponseEntity<SimpleEventReadResponse> getEvents(@RequestParam String location,
+                                                             @AuthUser User user,
                                                              @PageableDefault(size=20, sort="expiredAt", direction = Sort.Direction.DESC) Pageable pageable){
-        return ResponseEntity.ok(eventService.getEventsByLocation(location, pageable));
+        return ResponseEntity.ok(eventService.getEventsByLocation(location, user.getEmail(), pageable));
     }
 
     @GetMapping("events/{eventId}")
@@ -66,22 +67,21 @@ public class EventController {
     }
 
     @PostMapping("events/{eventId}/participants")
-    public ResponseEntity<Void> participateEventByUser(@PathVariable Long eventId,
-        @AuthUser User user) {
+    public ResponseEntity<Void> participateEventByUser(@PathVariable Long eventId, @AuthUser User user) {
         userEventService.participateEventByUser(user.getId(), eventId);
         return ResponseEntity.status(HttpStatus.CREATED).build();
     }
 
     @PatchMapping("events/{eventId}/participants")
-    public ResponseEntity<Void> completeEventByBusiness(@PathVariable Long eventId,
-        @AuthUser User user) {
+    public ResponseEntity<Void> completeEventByBusiness(@PathVariable Long eventId, @AuthUser User user) {
         userEventService.completeEventByBusiness(user.getId(), eventId);
         return ResponseEntity.ok().build();
     }
 
     @PatchMapping("events/{eventId}")
     public ResponseEntity<Void> updateEvent(@PathVariable Long eventId,
-        @RequestBody EventUpdateRequest eventUpdateRequest, @AuthUser User user) {
+                                            @RequestBody EventUpdateRequest eventUpdateRequest,
+                                            @AuthUser User user) {
         eventService.update(eventId, user.getId(), eventUpdateRequest);
         return ResponseEntity.ok().build();
     }

--- a/src/main/java/kdt/prgrms/kazedon/everevent/domain/event/Event.java
+++ b/src/main/java/kdt/prgrms/kazedon/everevent/domain/event/Event.java
@@ -20,6 +20,7 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.Formula;
 
 @Entity
 @Table(name = "event")
@@ -57,7 +58,7 @@ public class Event extends BaseTimeEntity {
   @Column(nullable = false)
   private int likeCount;
 
-  @Column(nullable = false)
+  @Formula("select count(1) from REVIEW r where r.event_id = id")
   private int reviewCount;
 
   @Builder
@@ -79,6 +80,14 @@ public class Event extends BaseTimeEntity {
 
   public void minusOneLike() {
     this.likeCount--;
+  }
+
+  public void plusParticipantCount() {
+    this.participantCount++;
+  }
+
+  public void minusParticipantCount() {
+    this.participantCount--;
   }
 
   public void modifyDescription(String description) {

--- a/src/main/java/kdt/prgrms/kazedon/everevent/domain/event/dto/SimpleEvent.java
+++ b/src/main/java/kdt/prgrms/kazedon/everevent/domain/event/dto/SimpleEvent.java
@@ -1,5 +1,6 @@
 package kdt.prgrms.kazedon.everevent.domain.event.dto;
 
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -7,6 +8,7 @@ import java.time.LocalDateTime;
 
 @Getter
 @Builder
+@AllArgsConstructor
 public class SimpleEvent {
     private Long eventId;
     private String eventName;

--- a/src/main/java/kdt/prgrms/kazedon/everevent/service/EventService.java
+++ b/src/main/java/kdt/prgrms/kazedon/everevent/service/EventService.java
@@ -10,6 +10,8 @@ import kdt.prgrms.kazedon.everevent.domain.event.repository.EventRepository;
 import kdt.prgrms.kazedon.everevent.domain.like.repository.EventLikeRepository;
 import kdt.prgrms.kazedon.everevent.domain.market.Market;
 import kdt.prgrms.kazedon.everevent.domain.market.repository.MarketRepository;
+import kdt.prgrms.kazedon.everevent.domain.user.User;
+import kdt.prgrms.kazedon.everevent.domain.user.repository.UserRepository;
 import kdt.prgrms.kazedon.everevent.domain.userevent.UserEvent;
 import kdt.prgrms.kazedon.everevent.domain.userevent.repository.UserEventRepository;
 import kdt.prgrms.kazedon.everevent.exception.ErrorMessage;
@@ -31,6 +33,7 @@ import org.springframework.web.multipart.MultipartFile;
 @RequiredArgsConstructor
 public class EventService {
 
+  private final UserRepository userRepository;
   private final EventRepository eventRepository;
   private final EventPictureRepository eventPictureRepository;
   private final MarketRepository marketRepository;
@@ -40,13 +43,11 @@ public class EventService {
   private final FileService fileService;
 
   @Transactional(readOnly = true)
-  public SimpleEventReadResponse getEventsByLocation(String location, Pageable pageable) {
-    boolean isLike = false;
+  public SimpleEventReadResponse getEventsByLocation(String location, String userEmail, Pageable pageable) {
+    User user = userRepository.findByEmail(userEmail)
+            .orElseThrow(()-> new NotFoundException(ErrorMessage.USER_NOT_FOUNDED, userEmail));
 
-    Page<SimpleEvent> simpleEvents = eventRepository
-        .findByLocation(location, pageable)
-        .map(event -> eventConverter.convertToSimpleEvent(event, isLike));
-    //      .filter(condition checking if the user likes this event using [event_like] table)
+    Page<SimpleEvent> simpleEvents = eventRepository.findByLocation(location, user.getId(), pageable);
 
     return eventConverter.convertToSimpleEventReadResponse(simpleEvents);
   }

--- a/src/main/java/kdt/prgrms/kazedon/everevent/service/UserEventService.java
+++ b/src/main/java/kdt/prgrms/kazedon/everevent/service/UserEventService.java
@@ -25,25 +25,38 @@ public class UserEventService {
   public void participateEventByUser(Long userId, Long eventId) {
     User user = userRepository.findById(userId)
         .orElseThrow(() -> new NotFoundException(ErrorMessage.USER_NOT_FOUNDED, userId));
+
     Event event = eventRepository.findById(eventId)
         .orElseThrow(() -> new NotFoundException(ErrorMessage.EVENT_NOT_FOUNDED, eventId));
+
     if (userEventRepository.existsUserEventsByUserIdAndEventId(userId, eventId)) {
       throw new AlreadyParticipateException(ErrorMessage.DUPLICATE_PARTICIPATE_EVENT, eventId);
     }
-    UserEvent userEvent = UserEvent.builder().user(user).event(event).build();
+
+    UserEvent userEvent = UserEvent.builder()
+            .user(user)
+            .event(event)
+            .build();
+
     userEvent.participateByUser();
+
     userEventRepository.save(userEvent);
+
+    event.plusParticipantCount();
   }
 
   @Transactional
   public void completeEventByBusiness(Long userId, Long eventId) {
     eventRepository.findById(eventId)
         .orElseThrow(() -> new NotFoundException(ErrorMessage.EVENT_NOT_FOUNDED, eventId));
+
     UserEvent userEvent = userEventRepository.findByUserIdAndEventId(userId, eventId)
         .orElseThrow(() -> new NotFoundException(ErrorMessage.PARTICIPATED_NOT_FOUNDED, eventId));
+
     if (userEvent.isCompleted()) {
       throw new AlreadyParticipateException(ErrorMessage.DUPLICATE_COMPLETED_EVENT, eventId);
     }
+
     userEvent.completeByBusiness();
   }
 }

--- a/src/test/java/kdt/prgrms/kazedon/everevent/controller/EventControllerTest.java
+++ b/src/test/java/kdt/prgrms/kazedon/everevent/controller/EventControllerTest.java
@@ -132,13 +132,14 @@ class EventControllerTest {
     void getEventsByLocation() throws Exception {
         //Given
         String location = "test-location";
-        when(eventService.getEventsByLocation(location, pageable)).thenReturn(simpleEventReadResponse);
+        when(customUserDetailService.loadUserByUsername(user.getEmail())).thenReturn(new CustomUserDetails(user));
+        when(eventService.getEventsByLocation(location, user.getEmail(), pageable)).thenReturn(simpleEventReadResponse);
 
         //When
         //Then
         mockMvc.perform(get("/api/v1/events")
                 .contentType(MediaType.APPLICATION_JSON)
-                .queryParam("location", location))
+                .queryParam("location", location).header("X-AUTH-TOKEN", token))
             .andExpect(status().isOk())
             .andReturn();
     }

--- a/src/test/java/kdt/prgrms/kazedon/everevent/service/EventServiceTest.java
+++ b/src/test/java/kdt/prgrms/kazedon/everevent/service/EventServiceTest.java
@@ -57,9 +57,6 @@ class EventServiceTest {
     private UserEventRepository userEventRepository;
 
     @Mock
-    private EventLikeRepository likeRepository;
-
-    @Mock
     private UserRepository userRepository;
 
     @Mock
@@ -171,7 +168,7 @@ class EventServiceTest {
         when(userRepository.findByEmail(user.getEmail())).thenReturn(Optional.of(user));
 
         //When
-        SimpleEventReadResponse response = eventService.getEventsByLocation(location, user.getEmail(), pageable);
+        eventService.getEventsByLocation(location, user.getEmail(), pageable);
 
         //Then
         verify(eventRepository).findByLocation(location, user.getId(), pageable);
@@ -187,7 +184,7 @@ class EventServiceTest {
         when(eventConverter.convertToDetailEventReadResponse(event, false, false, false)).thenReturn(detailEventReadResponse);
 
         //When
-        DetailEventReadResponse response = eventService.getEventById(eventId);
+        eventService.getEventById(eventId);
 
         //Then
         verify(eventRepository).findById(eventId);
@@ -210,7 +207,6 @@ class EventServiceTest {
     @Test
     void createEvent(){
         //Given
-        Long eventId = 1L;
         Long marketId = createRequest.getMarketId();
 
         when(marketRepository.findById(marketId)).thenReturn(Optional.of(market));
@@ -273,7 +269,7 @@ class EventServiceTest {
     }
 
     @Test
-    public void getEventsParticipatedByUserTest() {
+    void getEventsParticipatedByUserTest() {
         //Given
         UserEvent userEvent = UserEvent.builder().user(user).event(event).build();
         List<UserEvent> userEvents = List.of(userEvent);
@@ -304,7 +300,7 @@ class EventServiceTest {
     }
 
     @Test
-    public void updateTest() {
+    void updateTest() {
         //Given
         given(eventRepository.findById(event.getId())).willReturn(Optional.ofNullable(event));
         event.modifyDescription("수정");

--- a/src/test/java/kdt/prgrms/kazedon/everevent/service/EventServiceTest.java
+++ b/src/test/java/kdt/prgrms/kazedon/everevent/service/EventServiceTest.java
@@ -4,9 +4,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.BDDMockito.given;
-import static org.mockito.Mockito.any;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 
 import java.time.LocalDateTime;
 import java.util.ArrayList;
@@ -26,6 +24,7 @@ import kdt.prgrms.kazedon.everevent.domain.like.repository.EventLikeRepository;
 import kdt.prgrms.kazedon.everevent.domain.market.Market;
 import kdt.prgrms.kazedon.everevent.domain.market.repository.MarketRepository;
 import kdt.prgrms.kazedon.everevent.domain.user.User;
+import kdt.prgrms.kazedon.everevent.domain.user.repository.UserRepository;
 import kdt.prgrms.kazedon.everevent.domain.userevent.UserEvent;
 import kdt.prgrms.kazedon.everevent.domain.userevent.repository.UserEventRepository;
 import kdt.prgrms.kazedon.everevent.exception.NotFoundException;
@@ -59,6 +58,9 @@ class EventServiceTest {
 
     @Mock
     private EventLikeRepository likeRepository;
+
+    @Mock
+    private UserRepository userRepository;
 
     @Mock
     private Pageable pageable;
@@ -162,21 +164,19 @@ class EventServiceTest {
     @Test
     void getEventsByLocation() {
         //Given
-        Page<Event> events = new PageImpl<>(List.of(event, anotherEvent));
+        Page<SimpleEvent> events = new PageImpl<>(List.of(simpleEvent, anotherSimpleEvent));
         String location = "test-location";
 
-        when(eventRepository.findByLocation(location, pageable)).thenReturn(events);
-        when(eventConverter.convertToSimpleEvent(event, false)).thenReturn(simpleEvent);
-        when(eventConverter.convertToSimpleEvent(anotherEvent, false)).thenReturn(anotherSimpleEvent);
+        when(eventRepository.findByLocation(location, user.getId(), pageable)).thenReturn(events);
+        when(userRepository.findByEmail(user.getEmail())).thenReturn(Optional.of(user));
 
         //When
-        SimpleEventReadResponse response = eventService.getEventsByLocation(location, pageable);
+        SimpleEventReadResponse response = eventService.getEventsByLocation(location, user.getEmail(), pageable);
 
         //Then
-        verify(eventRepository).findByLocation(location, pageable);
-        verify(eventConverter).convertToSimpleEvent(event, false);
-        verify(eventConverter).convertToSimpleEvent(anotherEvent, false);
-        verify(eventConverter).convertToSimpleEventReadResponse(any());
+        verify(eventRepository).findByLocation(location, user.getId(), pageable);
+        verify(userRepository).findByEmail(user.getEmail());
+        verify(eventConverter).convertToSimpleEventReadResponse(events);
     }
 
     @Test


### PR DESCRIPTION
## 👩‍💻 요구 사항과 구현 내용
- 이벤트 참여 시 Event의 participantCount 증가하도록 코드 수정
- Event 엔티티의 reviewCount를 @Formula로 변경
- 이벤트 리스트 조회 시 사용자의 좋아요, 리뷰 수, 좋아요 수 반영

## ✅ 피드백 반영사항

## 🤔 PR 포인트 & 궁금한 점
- **프론트엔드에서 요구한 로그인되지 않은 사용자에 대한 이벤트 목록을 보여주는 기능은 별도의 이슈를 만들어 작업하겠습니다!**
- reviewCount는 정렬 기준이 되지 않기 때문에, Table의 컬럼으로 될 필요가 없습니다. 따라서 @Formula를 이용하여 count를 계산했습니다.
- API 개발 완료하면 QueryDSL 적용하면 좋겠네요! 에디와 리엔 쿼리문 짜는 데 도움 주셔서 너무 감사드립니다 ❤️ 

## 관련 이슈 
TLVB-134
