### PR TITLE
[TLVB-164] 비로그인 사용자의 이벤트 목록 조회 기능 추가, 패스워드 규칙 변경

### DIFF
--- a/src/main/java/kdt/prgrms/kazedon/everevent/controller/EventController.java
+++ b/src/main/java/kdt/prgrms/kazedon/everevent/controller/EventController.java
@@ -43,6 +43,10 @@ public class EventController {
     public ResponseEntity<SimpleEventReadResponse> getEvents(@RequestParam String location,
                                                              @AuthUser User user,
                                                              @PageableDefault(size=20, sort="expiredAt", direction = Sort.Direction.DESC) Pageable pageable){
+        if(user == null){
+            return ResponseEntity.ok(eventService.getEventsByLocation(location, pageable));
+        }
+
         return ResponseEntity.ok(eventService.getEventsByLocation(location, user.getEmail(), pageable));
     }
 

--- a/src/main/java/kdt/prgrms/kazedon/everevent/domain/event/repository/EventRepository.java
+++ b/src/main/java/kdt/prgrms/kazedon/everevent/domain/event/repository/EventRepository.java
@@ -34,7 +34,6 @@ public interface EventRepository extends JpaRepository<Event, Long> {
             + "WHERE e.market.address LIKE %:location% "
             + "GROUP BY e.id")
     Page<SimpleEvent> findByLocation(@Param("location") String location, Pageable pageable);
-
-
+    
     Page<Event> findByMarket(Market market, Pageable pageable);
 }

--- a/src/main/java/kdt/prgrms/kazedon/everevent/domain/event/repository/EventRepository.java
+++ b/src/main/java/kdt/prgrms/kazedon/everevent/domain/event/repository/EventRepository.java
@@ -25,5 +25,16 @@ public interface EventRepository extends JpaRepository<Event, Long> {
             + "GROUP BY e.id")
     Page<SimpleEvent> findByLocation(@Param("location") String location, @Param("userId") Long userId, Pageable pageable);
 
+    @Query("SELECT "
+            + "new kdt.prgrms.kazedon.everevent.domain.event.dto.SimpleEvent"
+            + "(e.id, e.name, e.expiredAt, e.market.name, MIN(ep.url), e.likeCount, e.reviewCount"
+            + ", false, e.maxParticipants - e.participantCount) "
+            + "FROM Event e "
+            + "LEFT JOIN EventPicture ep ON e.id = ep.event.id "
+            + "WHERE e.market.address LIKE %:location% "
+            + "GROUP BY e.id")
+    Page<SimpleEvent> findByLocation(@Param("location") String location, Pageable pageable);
+
+
     Page<Event> findByMarket(Market market, Pageable pageable);
 }

--- a/src/main/java/kdt/prgrms/kazedon/everevent/domain/user/dto/SignUpRequest.java
+++ b/src/main/java/kdt/prgrms/kazedon/everevent/domain/user/dto/SignUpRequest.java
@@ -20,7 +20,7 @@ public class SignUpRequest {
   private String email;
 
   @NotBlank(message = "비밀번호를 작성해주세요.")
-  @Pattern(regexp = "^[a-zA-Z0-9]{6,100}$")
+  @Pattern(regexp = "^(?=.*\\d)(?=.*[a-z])(?=.*[A-Z])(?=.*[a-zA-Z]).{6,100}$")
   private String password;
 
   @NotBlank(message = "닉네임을 작성해주세요.")

--- a/src/main/java/kdt/prgrms/kazedon/everevent/domain/user/dto/UserUpdateRequest.java
+++ b/src/main/java/kdt/prgrms/kazedon/everevent/domain/user/dto/UserUpdateRequest.java
@@ -23,6 +23,6 @@ public class UserUpdateRequest {
     private String nickname;
 
     @Size(max = 100)
-    @Pattern(regexp = "^[a-zA-Z0-9]{6,100}$")
+    @Pattern(regexp = "^(?=.*\\d)(?=.*[a-z])(?=.*[A-Z])(?=.*[a-zA-Z]).{6,100}$")
     private String password;
 }

--- a/src/main/java/kdt/prgrms/kazedon/everevent/service/EventService.java
+++ b/src/main/java/kdt/prgrms/kazedon/everevent/service/EventService.java
@@ -53,6 +53,12 @@ public class EventService {
   }
 
   @Transactional(readOnly = true)
+  public SimpleEventReadResponse getEventsByLocation(String location, Pageable pageable) {
+    Page<SimpleEvent> simpleEvents = eventRepository.findByLocation(location, pageable);
+    return eventConverter.convertToSimpleEventReadResponse(simpleEvents);
+  }
+
+  @Transactional(readOnly = true)
   public DetailEventReadResponse getEventById(Long id) {
     boolean isLike = false;
     boolean isFavorite = false;


### PR DESCRIPTION
## 👩‍💻 요구 사항과 구현 내용
이벤트 목록 조회 API에서 로그인하지 않은 사용자도 이벤트 목록을 조회할 수 있도록 기능을 추가하였습니다.

패스워드 규칙을 지난 스크럼에서 얘기한 바와 같이 변경하였습니다.
- 6자 이상 100자 이하
- 최소 1자 이상의 소문자, 대문자, 숫자 모두 포함해야 함
- 특수 문자 포함 가능

## ✅ 피드백 반영사항

## 🤔 PR 포인트 & 궁금한 점

## 관련 이슈 
TLVB-164, TLVB-166