### PR TITLE
[TLVB-174] Controller의 (@AuthUser) User 객체 전달 방법 수정

### DIFF
--- a/src/main/java/kdt/prgrms/kazedon/everevent/controller/EventController.java
+++ b/src/main/java/kdt/prgrms/kazedon/everevent/controller/EventController.java
@@ -43,24 +43,20 @@ public class EventController {
     public ResponseEntity<SimpleEventReadResponse> getEvents(@RequestParam String location,
                                                              @AuthUser User user,
                                                              @PageableDefault(size=20, sort="expiredAt", direction = Sort.Direction.DESC) Pageable pageable){
-        if(user == null){
-            return ResponseEntity.ok(eventService.getEventsByLocation(location, pageable));
-        }
-
-        return ResponseEntity.ok(eventService.getEventsByLocation(location, user.getEmail(), pageable));
+        return ResponseEntity.ok(eventService.getEventsByLocation(location, user, pageable));
     }
 
     @GetMapping("events/{eventId}")
     public ResponseEntity<DetailEventReadResponse> getEvent(@PathVariable("eventId") Long eventId,
         @AuthUser User user) {
-        return ResponseEntity.ok(eventService.getEventById(eventId, user.getEmail()));
+        return ResponseEntity.ok(eventService.getEventById(eventId, user));
     }
 
     @PostMapping(path = "events", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     public ResponseEntity<Long> createEvent(@Valid @RequestPart EventCreateRequest request,
                                             @RequestPart(required = false) List<MultipartFile> files,
                                             @AuthUser User user){
-        Long eventId = eventService.createEvent(request, files);
+        Long eventId = eventService.createEvent(request, files, user);
 
         URI location = ServletUriComponentsBuilder
                 .fromCurrentRequest().path("/{eventId}")
@@ -72,13 +68,13 @@ public class EventController {
 
     @PostMapping("events/{eventId}/participants")
     public ResponseEntity<Void> participateEventByUser(@PathVariable Long eventId, @AuthUser User user) {
-        userEventService.participateEventByUser(user.getId(), eventId);
+        userEventService.participateEventByUser(user, eventId);
         return ResponseEntity.status(HttpStatus.CREATED).build();
     }
 
     @PatchMapping("events/{eventId}/participants")
     public ResponseEntity<Void> completeEventByBusiness(@PathVariable Long eventId, @AuthUser User user) {
-        userEventService.completeEventByBusiness(user.getId(), eventId);
+        userEventService.completeEventByBusiness(user, eventId);
         return ResponseEntity.ok().build();
     }
 
@@ -86,7 +82,7 @@ public class EventController {
     public ResponseEntity<Void> updateEvent(@PathVariable Long eventId,
                                             @RequestBody EventUpdateRequest eventUpdateRequest,
                                             @AuthUser User user) {
-        eventService.update(eventId, user.getId(), eventUpdateRequest);
+        eventService.update(eventId, user, eventUpdateRequest);
         return ResponseEntity.ok().build();
     }
 

--- a/src/main/java/kdt/prgrms/kazedon/everevent/controller/FavoriteController.java
+++ b/src/main/java/kdt/prgrms/kazedon/everevent/controller/FavoriteController.java
@@ -22,14 +22,14 @@ public class FavoriteController {
   @PostMapping("/favorites/markets/{marketId}")
   public ResponseEntity<Void> addFavorite(@AuthUser User user,
       @PathVariable Long marketId){
-    Long favoriteId = favoriteService.addFavorite(user.getId(), marketId);
+    Long favoriteId = favoriteService.addFavorite(user, marketId);
     return ResponseEntity.created(linkTo(FavoriteController.class).toUri()).build();
   }
 
   @DeleteMapping("/favorites/markets/{marketId}")
   public ResponseEntity<Void> deleteFavorite(@AuthUser User user,
       @PathVariable Long marketId){
-    Long deleteId = favoriteService.deleteFavorite(user.getId(), marketId);
+    Long deleteId = favoriteService.deleteFavorite(user, marketId);
     return ResponseEntity.noContent().build();
   }
 }

--- a/src/main/java/kdt/prgrms/kazedon/everevent/controller/LikeController.java
+++ b/src/main/java/kdt/prgrms/kazedon/everevent/controller/LikeController.java
@@ -19,14 +19,14 @@ public class LikeController {
   @PostMapping("/likes/events/{eventId}")
   public ResponseEntity<Void> addLike(@AuthUser User user,
       @PathVariable Long eventId){
-    likeService.addLike(user.getId(), eventId);
+    likeService.addLike(user, eventId);
     return ResponseEntity.created(linkTo(LikeController.class).toUri()).build();
   }
 
   @DeleteMapping("/likes/events/{eventId}")
   public ResponseEntity<Void> deleteLike(@AuthUser User user,
       @PathVariable Long eventId){
-    likeService.deleteLike(user.getId(), eventId);
+    likeService.deleteLike(user, eventId);
     return ResponseEntity.noContent().build();
   }
 }

--- a/src/main/java/kdt/prgrms/kazedon/everevent/controller/MarketController.java
+++ b/src/main/java/kdt/prgrms/kazedon/everevent/controller/MarketController.java
@@ -22,7 +22,7 @@ public class MarketController {
 
     @GetMapping("markets")
     public ResponseEntity<MyMarketReadResponse> getMarkets(@AuthUser User user) {
-        return ResponseEntity.ok(marketService.getMarketsByUser(user.getId()));
+        return ResponseEntity.ok(marketService.getMarketsByUser(user));
     }
 
     @GetMapping("markets/{marketId}")
@@ -33,7 +33,7 @@ public class MarketController {
     @PostMapping("markets")
     public ResponseEntity<Void> createMarket(@Valid @RequestBody MarketCreateRequest marketCreateRequest,
         @AuthUser User user) {
-        marketService.createMarket(marketCreateRequest, user.getId());
+        marketService.createMarket(marketCreateRequest, user);
 
         URI location = ServletUriComponentsBuilder
             .fromCurrentRequest()

--- a/src/main/java/kdt/prgrms/kazedon/everevent/controller/UserController.java
+++ b/src/main/java/kdt/prgrms/kazedon/everevent/controller/UserController.java
@@ -103,12 +103,12 @@ public class UserController {
 
   @GetMapping("/members")
   public ResponseEntity<UserReadResponse> getUser(@AuthUser User user) {
-    return ResponseEntity.ok(userService.getUser(user.getId()));
+    return ResponseEntity.ok(userService.getUser(user));
   }
 
   @PutMapping("/members")
   public ResponseEntity<Void> updateUser(@RequestBody @Valid UserUpdateRequest updateRequest, @AuthUser User user){
-    userService.updateUser(updateRequest, user.getId());
+    userService.updateUser(updateRequest, user);
     return ResponseEntity.ok().build();
   }
 
@@ -143,7 +143,7 @@ public class UserController {
   @PostMapping("/members/check/password")
   public ResponseEntity<Void> checkPassword(@RequestBody CheckPasswordRequest request,
       @AuthUser User user) {
-    userService.checkPassword(user.getEmail(), request.getPassword());
+    userService.checkPassword(user, request.getPassword());
     return ResponseEntity.ok().build();
   }
 

--- a/src/main/java/kdt/prgrms/kazedon/everevent/domain/event/repository/EventRepository.java
+++ b/src/main/java/kdt/prgrms/kazedon/everevent/domain/event/repository/EventRepository.java
@@ -21,8 +21,8 @@ public interface EventRepository extends JpaRepository<Event, Long> {
         + ", CASE WHEN el.id IS null THEN false ELSE true END"
         + ", e.maxParticipants - e.participantCount) "
         + "FROM Event e "
-        + "LEFT OUTER JOIN EventPicture ep ON e.id = ep.event.id "
-        + "LEFT OUTER JOIN EventLike el ON (e.id = el.event.id AND el.user.id = :userId) "
+        + "LEFT JOIN EventPicture ep ON e.id = ep.event.id "
+        + "LEFT JOIN EventLike el ON (e.id = el.event.id AND el.user.id = :userId) "
         + "WHERE e.market.address LIKE %:location% "
         + "GROUP BY e.id")
     Page<SimpleEvent> findByLocation(@Param("location") String location,

--- a/src/main/java/kdt/prgrms/kazedon/everevent/domain/event/repository/EventRepository.java
+++ b/src/main/java/kdt/prgrms/kazedon/everevent/domain/event/repository/EventRepository.java
@@ -21,8 +21,8 @@ public interface EventRepository extends JpaRepository<Event, Long> {
         + ", CASE WHEN el.id IS null THEN false ELSE true END"
         + ", e.maxParticipants - e.participantCount) "
         + "FROM Event e "
-        + "LEFT JOIN EventPicture ep ON e.id = ep.event.id "
-        + "LEFT JOIN EventLike el ON (e.id = el.event.id AND el.user.id = :userId) "
+        + "LEFT OUTER JOIN EventPicture ep ON e.id = ep.event.id "
+        + "LEFT OUTER JOIN EventLike el ON (e.id = el.event.id AND el.user.id = :userId) "
         + "WHERE e.market.address LIKE %:location% "
         + "GROUP BY e.id")
     Page<SimpleEvent> findByLocation(@Param("location") String location,

--- a/src/main/java/kdt/prgrms/kazedon/everevent/domain/market/repository/MarketRepository.java
+++ b/src/main/java/kdt/prgrms/kazedon/everevent/domain/market/repository/MarketRepository.java
@@ -13,4 +13,8 @@ import org.springframework.stereotype.Repository;
 @Repository
 public interface MarketRepository extends JpaRepository<Market, Long> {
     Optional<Market> findByUser(User user);
+
+    @Query("SELECT CASE WHEN COUNT(m)> 0 THEN true ELSE false END FROM Market m "
+        + "WHERE m.user.id = :userId AND m.id = :marketId")
+    boolean isPossibleToCreateEvent(Long marketId, Long userId);
 }

--- a/src/main/java/kdt/prgrms/kazedon/everevent/exception/ErrorMessage.java
+++ b/src/main/java/kdt/prgrms/kazedon/everevent/exception/ErrorMessage.java
@@ -24,7 +24,8 @@ public enum ErrorMessage {
   ALREADY_REGISTER_MARKET("이미 가게를 등록했습니다."),
   LOGIN_FAILED("이메일 {0}은 로그인에 실패했습니다."),
   INVALID_PASSWORD("이메일 {0}의 기존 비밀번호와 일치하지 않습니다."),
-  INVALID_TOKEN("{0}는 만료 또는 잘못된 토큰입니다.");
+  INVALID_TOKEN("{0}는 만료 또는 잘못된 토큰입니다."),
+  UNAUTHORIZED_CREATE_EVENT("사용자 {0}은 이벤트를 만들 권한이 없습니다");
 
   private final String message;
 

--- a/src/main/java/kdt/prgrms/kazedon/everevent/service/EventService.java
+++ b/src/main/java/kdt/prgrms/kazedon/everevent/service/EventService.java
@@ -53,8 +53,12 @@ public class EventService {
   @Transactional(readOnly = true)
   public SimpleEventReadResponse getEventsByLocation(String location, User user,
       Pageable pageable) {
-    Page<SimpleEvent> simpleEvents = eventRepository.findByLocation(location, user.getId(),
-        pageable);
+    Page<SimpleEvent> simpleEvents;
+    if(user == null)
+      simpleEvents = eventRepository.findByLocation(location, pageable);
+    else
+      simpleEvents = eventRepository.findByLocation(location, user.getId(), pageable);
+
     return eventConverter.convertToSimpleEventReadResponse(simpleEvents);
   }
 

--- a/src/main/java/kdt/prgrms/kazedon/everevent/service/FavoriteService.java
+++ b/src/main/java/kdt/prgrms/kazedon/everevent/service/FavoriteService.java
@@ -29,13 +29,11 @@ public class FavoriteService {
   private final MarketRepository marketRepository;
 
   @Transactional
-  public Long addFavorite(Long userId, Long marketId){
-    User user = userRepository.findById(userId)
-        .orElseThrow(() -> new NotFoundException(ErrorMessage.USER_NOT_FOUNDED, userId));
+  public Long addFavorite(User user, Long marketId){
     Market market = marketRepository.findById(marketId)
         .orElseThrow(() -> new NotFoundException(ErrorMessage.MARKET_NOT_FOUNDED, marketId));
-    if(favoriteRepository.existsFavoriteByUserIdAndMarketId(userId, marketId)){
-      throw new AlreadyFavoritedException(ErrorMessage.DUPLICATE_FAVORITE_MARKET,userId);
+    if(favoriteRepository.existsFavoriteByUserIdAndMarketId(user.getId(), marketId)){
+      throw new AlreadyFavoritedException(ErrorMessage.DUPLICATE_FAVORITE_MARKET,user.getId());
     }
     Favorite favorite = Favorite.builder().user(user).market(market).build();
     favoriteRepository.save(favorite);
@@ -44,13 +42,13 @@ public class FavoriteService {
   }
 
   @Transactional
-  public Long deleteFavorite(Long userId, Long marketId) {
+  public Long deleteFavorite(User user, Long marketId) {
     Market market = marketRepository.findById(marketId)
         .orElseThrow(() -> new NotFoundException(ErrorMessage.MARKET_NOT_FOUNDED, marketId));
-    Favorite favorite = favoriteRepository.findByUserIdAndMarketId(userId, marketId)
+    Favorite favorite = favoriteRepository.findByUserIdAndMarketId(user.getId(), marketId)
         .orElseThrow(
             () -> new AlreadyFavoritedException(ErrorMessage.FAVORITE_NOT_FOUNDED, marketId));
-    if (!favoriteRepository.existsFavoriteByUserIdAndMarketId(userId, marketId)) {
+    if (!favoriteRepository.existsFavoriteByUserIdAndMarketId(user.getId(), marketId)) {
       throw new AlreadyFavoritedException(ErrorMessage.DUPLICATE_NOT_FAVORITE_MARKET,
           favorite.getId());
     }

--- a/src/main/java/kdt/prgrms/kazedon/everevent/service/LikeService.java
+++ b/src/main/java/kdt/prgrms/kazedon/everevent/service/LikeService.java
@@ -29,15 +29,12 @@ public class LikeService {
   private final EventRepository eventRepository;
 
   @Transactional
-  public void addLike(Long userId, Long eventId) {
-    User user = userRepository.findById(userId)
-        .orElseThrow(() -> new NotFoundException(ErrorMessage.USER_NOT_FOUNDED, userId));
-
+  public void addLike(User user, Long eventId) {
     Event event = eventRepository.findById(eventId)
         .orElseThrow(() -> new NotFoundException(ErrorMessage.EVENT_NOT_FOUNDED, eventId));
 
-    if (eventLikeRepository.existsEventLikeByUserIdAndEventId(userId, eventId)) {
-      throw new AlreadyEventLikeException(ErrorMessage.DUPLICATE_EVENT_LIKE, userId);
+    if (eventLikeRepository.existsEventLikeByUserIdAndEventId(user.getId(), eventId)) {
+      throw new AlreadyEventLikeException(ErrorMessage.DUPLICATE_EVENT_LIKE, user.getId());
     }
 
     EventLike eventLike = EventLike.builder()
@@ -50,11 +47,11 @@ public class LikeService {
   }
 
   @Transactional
-  public void deleteLike(Long userId, Long eventId) {
+  public void deleteLike(User user, Long eventId) {
     Event event = eventRepository.findById(eventId)
         .orElseThrow(() -> new NotFoundException(ErrorMessage.EVENT_NOT_FOUNDED, eventId));
 
-    EventLike eventLike = eventLikeRepository.findByUserIdAndEventId(userId, eventId)
+    EventLike eventLike = eventLikeRepository.findByUserIdAndEventId(user.getId(), eventId)
         .orElseThrow(() -> new NotFoundException(ErrorMessage.EVENTLIKE_NOT_FOUNDED, eventId));
 
     eventLikeRepository.deleteById(eventLike.getId());

--- a/src/main/java/kdt/prgrms/kazedon/everevent/service/MarketService.java
+++ b/src/main/java/kdt/prgrms/kazedon/everevent/service/MarketService.java
@@ -24,13 +24,9 @@ public class MarketService {
     private final UserService userService;
 
     @Transactional(readOnly = true)
-    public MyMarketReadResponse getMarketsByUser(Long userId) {
-
-        User user = userRepository.findById(userId)
-            .orElseThrow(() -> new NotFoundException(ErrorMessage.USER_NOT_FOUNDED, userId));
-
+    public MyMarketReadResponse getMarketsByUser(User user) {
         Market market = marketRepository.findByUser(user)
-            .orElseThrow(() -> new NotFoundException(ErrorMessage.MARKET_NOT_FOUNDED, userId));
+            .orElseThrow(() -> new NotFoundException(ErrorMessage.MARKET_NOT_FOUNDED, user.getId()));
 
         return marketConverter.convertToSimpleMarket(market);
     }
@@ -44,10 +40,7 @@ public class MarketService {
     }
 
     @Transactional
-    public Long createMarket(MarketCreateRequest createRequest, Long userId) {
-        User user = userRepository.findById(userId)
-            .orElseThrow(() -> new NotFoundException(ErrorMessage.USER_NOT_FOUNDED, userId));
-
+    public Long createMarket(MarketCreateRequest createRequest, User user) {
         userService.changeAuthorityToBusiness(user.getEmail());
 
         Market market = marketConverter.convertToMarket(createRequest, user);

--- a/src/main/java/kdt/prgrms/kazedon/everevent/service/UserEventService.java
+++ b/src/main/java/kdt/prgrms/kazedon/everevent/service/UserEventService.java
@@ -22,14 +22,11 @@ public class UserEventService {
   private final UserEventRepository userEventRepository;
 
   @Transactional
-  public void participateEventByUser(Long userId, Long eventId) {
-    User user = userRepository.findById(userId)
-        .orElseThrow(() -> new NotFoundException(ErrorMessage.USER_NOT_FOUNDED, userId));
-
+  public void participateEventByUser(User user, Long eventId) {
     Event event = eventRepository.findById(eventId)
         .orElseThrow(() -> new NotFoundException(ErrorMessage.EVENT_NOT_FOUNDED, eventId));
 
-    if (userEventRepository.existsUserEventsByUserIdAndEventId(userId, eventId)) {
+    if (userEventRepository.existsUserEventsByUserIdAndEventId(user.getId(), eventId)) {
       throw new AlreadyParticipateException(ErrorMessage.DUPLICATE_PARTICIPATE_EVENT, eventId);
     }
 
@@ -46,11 +43,11 @@ public class UserEventService {
   }
 
   @Transactional
-  public void completeEventByBusiness(Long userId, Long eventId) {
+  public void completeEventByBusiness(User user, Long eventId) {
     eventRepository.findById(eventId)
         .orElseThrow(() -> new NotFoundException(ErrorMessage.EVENT_NOT_FOUNDED, eventId));
 
-    UserEvent userEvent = userEventRepository.findByUserIdAndEventId(userId, eventId)
+    UserEvent userEvent = userEventRepository.findByUserIdAndEventId(user.getId(), eventId)
         .orElseThrow(() -> new NotFoundException(ErrorMessage.PARTICIPATED_NOT_FOUNDED, eventId));
 
     if (userEvent.isCompleted()) {

--- a/src/main/java/kdt/prgrms/kazedon/everevent/service/UserService.java
+++ b/src/main/java/kdt/prgrms/kazedon/everevent/service/UserService.java
@@ -66,18 +66,12 @@ public class UserService {
     return roles;
   }
 
-  public UserReadResponse getUser(Long userId){
-    User retrievedUser = userRepository.findById(userId)
-            .orElseThrow(() -> new NotFoundException(ErrorMessage.USER_NOT_FOUNDED, userId));
-
-    return userConverter.convertToUserReadResponse(retrievedUser);
+  public UserReadResponse getUser(User user){
+    return userConverter.convertToUserReadResponse(user);
   }
 
   @Transactional
-  public Long updateUser(UserUpdateRequest updateRequest, Long userId){
-    User user = userRepository.findById(userId)
-            .orElseThrow(() -> new NotFoundException(ErrorMessage.USER_NOT_FOUNDED, userId));
-
+  public Long updateUser(UserUpdateRequest updateRequest, User user){
     if(updateRequest.getPassword() != null){
       user.changePassword(
               passwordEncoder.encode(updateRequest.getPassword())
@@ -107,11 +101,9 @@ public class UserService {
     return LoginResponse.builder().userId(user.getId()).nickname(user.getNickname()).build();
   }
 
-  public void checkPassword(String email, String password) {
-    User user = userRepository.findByEmail(email)
-        .orElseThrow(() -> new NotFoundException(ErrorMessage.USER_NOT_FOUNDED, email));
+  public void checkPassword(User user, String password) {
     if (!passwordEncoder.matches(password, user.getPassword())) {
-      throw new InvalidPasswordException(ErrorMessage.INVALID_PASSWORD, email);
+      throw new InvalidPasswordException(ErrorMessage.INVALID_PASSWORD, user.getEmail());
     }
   }
 }

--- a/src/test/java/kdt/prgrms/kazedon/everevent/service/EventServiceTest.java
+++ b/src/test/java/kdt/prgrms/kazedon/everevent/service/EventServiceTest.java
@@ -31,6 +31,7 @@ import kdt.prgrms.kazedon.everevent.domain.user.repository.UserRepository;
 import kdt.prgrms.kazedon.everevent.domain.userevent.UserEvent;
 import kdt.prgrms.kazedon.everevent.domain.userevent.repository.UserEventRepository;
 import kdt.prgrms.kazedon.everevent.exception.NotFoundException;
+import kdt.prgrms.kazedon.everevent.exception.UnAuthorizedException;
 import kdt.prgrms.kazedon.everevent.service.converter.EventConverter;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -171,14 +172,12 @@ class EventServiceTest {
         String location = "test-location";
 
         when(eventRepository.findByLocation(location, user.getId(), pageable)).thenReturn(events);
-        when(userRepository.findByEmail(user.getEmail())).thenReturn(Optional.of(user));
 
         //When
         eventService.getEventsByLocation(location, user, pageable);
 
         //Then
         verify(eventRepository).findByLocation(location, user.getId(), pageable);
-        verify(userRepository).findByEmail(user.getEmail());
         verify(eventConverter).convertToSimpleEventReadResponse(events);
     }
 
@@ -197,7 +196,6 @@ class EventServiceTest {
             .isLike(false)
             .build();
 
-        when(userRepository.findByEmail(user.getEmail())).thenReturn(Optional.of(user));
         when(eventRepository.findDetailEventById(eventId, user.getId())).thenReturn(
             Optional.of(detailEvent));
         when(eventPictureRepository.findEventPictureUrlsByEventId(eventId)).thenReturn(
@@ -210,7 +208,6 @@ class EventServiceTest {
         eventService.getEventById(eventId, user);
 
         //Then
-        verify(userRepository).findByEmail(user.getEmail());
         verify(eventRepository).findDetailEventById(eventId, user.getId());
         verify(eventPictureRepository).findEventPictureUrlsByEventId(eventId);
         verify(eventConverter).convertToDetailEventReadResponse(detailEvent,
@@ -222,7 +219,6 @@ class EventServiceTest {
         //Given
         Long invalidEventId = Long.MAX_VALUE;
 
-        when(userRepository.findByEmail(user.getEmail())).thenReturn(Optional.of(user));
         when(eventRepository.findDetailEventById(invalidEventId, user.getId()))
             .thenReturn(Optional.empty());
         //When
@@ -230,7 +226,6 @@ class EventServiceTest {
             () -> eventService.getEventById(invalidEventId, user));
 
         //Then
-        verify(userRepository).findByEmail(user.getEmail());
         verify(eventRepository).findDetailEventById(invalidEventId, user.getId());
     }
 

--- a/src/test/java/kdt/prgrms/kazedon/everevent/service/EventServiceTest.java
+++ b/src/test/java/kdt/prgrms/kazedon/everevent/service/EventServiceTest.java
@@ -31,7 +31,6 @@ import kdt.prgrms.kazedon.everevent.domain.user.repository.UserRepository;
 import kdt.prgrms.kazedon.everevent.domain.userevent.UserEvent;
 import kdt.prgrms.kazedon.everevent.domain.userevent.repository.UserEventRepository;
 import kdt.prgrms.kazedon.everevent.exception.NotFoundException;
-import kdt.prgrms.kazedon.everevent.exception.UnAuthorizedException;
 import kdt.prgrms.kazedon.everevent.service.converter.EventConverter;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;

--- a/src/test/java/kdt/prgrms/kazedon/everevent/service/EventServiceTest.java
+++ b/src/test/java/kdt/prgrms/kazedon/everevent/service/EventServiceTest.java
@@ -174,7 +174,7 @@ class EventServiceTest {
         when(userRepository.findByEmail(user.getEmail())).thenReturn(Optional.of(user));
 
         //When
-        eventService.getEventsByLocation(location, user.getEmail(), pageable);
+        eventService.getEventsByLocation(location, user, pageable);
 
         //Then
         verify(eventRepository).findByLocation(location, user.getId(), pageable);
@@ -207,7 +207,7 @@ class EventServiceTest {
             detailEventReadResponse);
 
         //When
-        eventService.getEventById(eventId, user.getEmail());
+        eventService.getEventById(eventId, user);
 
         //Then
         verify(userRepository).findByEmail(user.getEmail());
@@ -227,7 +227,7 @@ class EventServiceTest {
             .thenReturn(Optional.empty());
         //When
         assertThrows(NotFoundException.class,
-            () -> eventService.getEventById(invalidEventId, user.getEmail()));
+            () -> eventService.getEventById(invalidEventId, user));
 
         //Then
         verify(userRepository).findByEmail(user.getEmail());
@@ -244,7 +244,7 @@ class EventServiceTest {
         when(eventRepository.save(event)).thenReturn(event);
 
         //When
-        eventService.createEvent(createRequest, new ArrayList<>());
+        eventService.createEvent(createRequest, new ArrayList<>(), user);
 
         //Then
         verify(marketRepository).findById(marketId);
@@ -260,7 +260,8 @@ class EventServiceTest {
 
         //When
         //Then
-        assertThrows(NotFoundException.class, () -> eventService.createEvent(invalidCreateRequest, new ArrayList<>()));
+        assertThrows(NotFoundException.class, () -> eventService.createEvent(invalidCreateRequest, new ArrayList<>(),
+            user));
         verify(marketRepository).findById(invalidMarketId);
     }
 
@@ -338,7 +339,7 @@ class EventServiceTest {
         EventUpdateRequest eventUpdateRequest = EventUpdateRequest.builder().description("수정")
             .build();
         //When
-        eventService.update(event.getId(), user.getId(), eventUpdateRequest);
+        eventService.update(event.getId(), user, eventUpdateRequest);
 
         //Then
         verify(eventRepository).findById(event.getId());

--- a/src/test/java/kdt/prgrms/kazedon/everevent/service/EventServiceTest.java
+++ b/src/test/java/kdt/prgrms/kazedon/everevent/service/EventServiceTest.java
@@ -234,6 +234,7 @@ class EventServiceTest {
         //Given
         Long marketId = createRequest.getMarketId();
 
+        when(marketRepository.isPossibleToCreateEvent(marketId, user.getId())).thenReturn(true);
         when(marketRepository.findById(marketId)).thenReturn(Optional.of(market));
         when(eventConverter.convertToEvent(createRequest, market)).thenReturn(event);
         when(eventRepository.save(event)).thenReturn(event);
@@ -242,6 +243,7 @@ class EventServiceTest {
         eventService.createEvent(createRequest, new ArrayList<>(), user);
 
         //Then
+        verify(marketRepository).isPossibleToCreateEvent(marketId, user.getId());
         verify(marketRepository).findById(marketId);
         verify(eventConverter).convertToEvent(createRequest, market);
         verify(eventRepository).save(event);
@@ -251,12 +253,14 @@ class EventServiceTest {
     void createEventUsingInvalidMarketId(){
         //Given
         Long invalidMarketId = invalidCreateRequest.getMarketId();
+        when(marketRepository.isPossibleToCreateEvent(invalidMarketId, user.getId())).thenReturn(true);
         when(marketRepository.findById(invalidMarketId)).thenReturn(Optional.empty());
 
         //When
         //Then
         assertThrows(NotFoundException.class, () -> eventService.createEvent(invalidCreateRequest, new ArrayList<>(),
             user));
+        verify(marketRepository).isPossibleToCreateEvent(invalidMarketId, user.getId());
         verify(marketRepository).findById(invalidMarketId);
     }
 

--- a/src/test/java/kdt/prgrms/kazedon/everevent/service/MarketServiceTest.java
+++ b/src/test/java/kdt/prgrms/kazedon/everevent/service/MarketServiceTest.java
@@ -84,14 +84,12 @@ class MarketServiceTest {
 
         when(marketConverter.convertToMarket(createRequest, user)).thenReturn(newMarket);
         when(marketRepository.save(newMarket)).thenReturn(newMarket);
-        when(userRepository.findById(any())).thenReturn(Optional.of(user));
         when(userService.changeAuthorityToBusiness(user.getEmail())).thenReturn(roles);
 
         //When
         marketService.createMarket(createRequest, user);
 
         //Then
-        verify(userRepository).findById(any());
         verify(marketConverter).convertToMarket(createRequest, user);
         verify(marketRepository).save(newMarket);
         verify(userService).changeAuthorityToBusiness(user.getEmail());
@@ -100,7 +98,6 @@ class MarketServiceTest {
     @Test
     void getMarketsByUser(){
         //Given
-        when(userRepository.findById(user.getId())).thenReturn(Optional.of(user));
         when(marketRepository.findByUser(user)).thenReturn(Optional.of(market));
         when(marketConverter.convertToSimpleMarket(market)).thenReturn(myMarket);
 

--- a/src/test/java/kdt/prgrms/kazedon/everevent/service/MarketServiceTest.java
+++ b/src/test/java/kdt/prgrms/kazedon/everevent/service/MarketServiceTest.java
@@ -88,7 +88,7 @@ class MarketServiceTest {
         when(userService.changeAuthorityToBusiness(user.getEmail())).thenReturn(roles);
 
         //When
-        marketService.createMarket(createRequest, user.getId());
+        marketService.createMarket(createRequest, user);
 
         //Then
         verify(userRepository).findById(any());
@@ -105,7 +105,7 @@ class MarketServiceTest {
         when(marketConverter.convertToSimpleMarket(market)).thenReturn(myMarket);
 
         //When
-        marketService.getMarketsByUser(user.getId());
+        marketService.getMarketsByUser(user);
 
         //Then
         verify(marketRepository).findByUser(user);

--- a/src/test/java/kdt/prgrms/kazedon/everevent/service/UserEventServiceTest.java
+++ b/src/test/java/kdt/prgrms/kazedon/everevent/service/UserEventServiceTest.java
@@ -58,7 +58,6 @@ class UserEventServiceTest {
   void participateEventByUser() {
     //Given
     userEvent.participateByUser();
-    when(userRepository.findById(user.getId())).thenReturn(Optional.of(user));
     when(eventRepository.findById(event.getId())).thenReturn(Optional.of(event));
     when(userEventRepository.existsUserEventsByUserIdAndEventId(user.getId(),
         event.getId())).thenReturn(false);
@@ -68,7 +67,6 @@ class UserEventServiceTest {
     userEventService.participateEventByUser(user, event.getId());
 
     //Then
-    verify(userRepository).findById(user.getId());
     verify(eventRepository).findById(event.getId());
     verify(userEventRepository).existsUserEventsByUserIdAndEventId(user.getId(), event.getId());
     verify(userEventRepository).save(any());

--- a/src/test/java/kdt/prgrms/kazedon/everevent/service/UserEventServiceTest.java
+++ b/src/test/java/kdt/prgrms/kazedon/everevent/service/UserEventServiceTest.java
@@ -65,7 +65,7 @@ class UserEventServiceTest {
     when(userEventRepository.save(any())).thenReturn(userEvent);
 
     //When
-    userEventService.participateEventByUser(user.getId(), event.getId());
+    userEventService.participateEventByUser(user, event.getId());
 
     //Then
     verify(userRepository).findById(user.getId());
@@ -83,7 +83,7 @@ class UserEventServiceTest {
         Optional.of(userEvent));
 
     //When
-    userEventService.completeEventByBusiness(user.getId(), event.getId());
+    userEventService.completeEventByBusiness(user, event.getId());
 
     //Then
     verify(eventRepository).findById(event.getId());

--- a/src/test/java/kdt/prgrms/kazedon/everevent/service/UserServiceTest.java
+++ b/src/test/java/kdt/prgrms/kazedon/everevent/service/UserServiceTest.java
@@ -249,12 +249,14 @@ class UserServiceTest {
     User business = new User(signUpRequest, encodedPassword);
     business.addAuthority(UserType.ROLE_BUSINESS);
     given(userRepository.save(any())).willReturn(business);
+    when(userRepository.findByEmail(user.getEmail())).thenReturn(Optional.of(user));
 
     //When
     List<UserType> userType = userService.changeAuthorityToBusiness(userEmail);
 
     //Then
     assertThat(userType, is(roles));
+    verify(userRepository).findByEmail(user.getEmail());
 
   }
 

--- a/src/test/java/kdt/prgrms/kazedon/everevent/service/UserServiceTest.java
+++ b/src/test/java/kdt/prgrms/kazedon/everevent/service/UserServiceTest.java
@@ -110,24 +110,24 @@ class UserServiceTest {
     when(userConverter.convertToUserReadResponse(user)).thenReturn(any());
 
     //When
-    userService.getUser(userId);
+    userService.getUser(user);
 
     //Then
     verify(userRepository).findById(userId);
     verify(userConverter).convertToUserReadResponse(user);
   }
 
-  @Test
-  void getNonExistingUser() {
-    //Given
-    Long invalidUserId = Long.MAX_VALUE;
-    when(userRepository.findById(invalidUserId)).thenReturn(Optional.empty());
-
-    //When
-    //Then
-    assertThrows(NotFoundException.class, () -> userService.getUser(invalidUserId));
-    verify(userRepository).findById(invalidUserId);
-  }
+//  @Test
+//  void getNonExistingUser() {
+//    //Given
+//    Long invalidUserId = Long.MAX_VALUE;
+//    when(userRepository.findById(invalidUserId)).thenReturn(Optional.empty());
+//
+//    //When
+//    //Then
+//    assertThrows(NotFoundException.class, () -> userService.getUser(invalidUserId));
+//    verify(userRepository).findById(invalidUserId);
+//  }
 
   @Test
   void updateUserNickname(){
@@ -143,7 +143,7 @@ class UserServiceTest {
     when(userRepository.save(user)).thenReturn(user);
 
     //When
-    userService.updateUser(updateRequest, userId);
+    userService.updateUser(updateRequest, user);
 
     //Then
     assertThat(user.getNickname(), is(updateRequest.getNickname()));
@@ -169,7 +169,7 @@ class UserServiceTest {
     when(userRepository.save(user)).thenReturn(user);
 
     //When
-    userService.updateUser(updateRequest, userId);
+    userService.updateUser(updateRequest, user);
 
     //Then
     assertNotNull(user.getNickname());
@@ -196,7 +196,7 @@ class UserServiceTest {
     when(userRepository.save(user)).thenReturn(user);
 
     //When
-    userService.updateUser(updateRequest, userId);
+    userService.updateUser(updateRequest, user);
 
     //Then
     assertThat(user.getNickname(), is(updateRequest.getNickname()));
@@ -223,7 +223,7 @@ class UserServiceTest {
     when(userRepository.existsByNickname(updateRequest.getNickname())).thenReturn(true);
 
     //When
-    assertThrows(DuplicateUserArgumentException.class, () -> userService.updateUser(updateRequest, userId));
+    assertThrows(DuplicateUserArgumentException.class, () -> userService.updateUser(updateRequest, user));
 
     //Then
     assertThat(user.getNickname(), not(updateRequest.getNickname()));
@@ -233,22 +233,22 @@ class UserServiceTest {
     verify(userRepository, times(1)).save(user);
   }
 
-  @Test
-  void updateNonExistingUser() {
-    //Given
-    Long invalidUserId = Long.MAX_VALUE;
-    UserUpdateRequest updateRequest = UserUpdateRequest.builder()
-        .nickname("new-nickname")
-        .password("new-password")
-        .build();
-
-    when(userRepository.findById(invalidUserId)).thenReturn(Optional.empty());
-
-    //When
-    //Then
-    assertThrows(NotFoundException.class, () -> userService.updateUser(updateRequest, invalidUserId));
-    verify(userRepository).findById(invalidUserId);
-  }
+//  @Test
+//  void updateNonExistingUser() {
+//    //Given
+//    Long invalidUserId = Long.MAX_VALUE;
+//    UserUpdateRequest updateRequest = UserUpdateRequest.builder()
+//        .nickname("new-nickname")
+//        .password("new-password")
+//        .build();
+//
+//    when(userRepository.findById(invalidUserId)).thenReturn(Optional.empty());
+//
+//    //When
+//    //Then
+//    assertThrows(NotFoundException.class, () -> userService.updateUser(updateRequest, invalidUserId));
+//    verify(userRepository).findById(invalidUserId);
+//  }
 
   @Test
   void changeAuthorityToBusinessTest() {
@@ -301,7 +301,7 @@ class UserServiceTest {
     when(passwordEncoder.matches(any(), any())).thenReturn(true);
 
     //When
-    userService.checkPassword(user1.getEmail(), user1.getPassword());
+    userService.checkPassword(user, user1.getPassword());
     
     //Then
     verify(userRepository).findByEmail(user1.getEmail());

--- a/src/test/java/kdt/prgrms/kazedon/everevent/service/UserServiceTest.java
+++ b/src/test/java/kdt/prgrms/kazedon/everevent/service/UserServiceTest.java
@@ -106,14 +106,12 @@ class UserServiceTest {
   void getUser() {
     //Given
     Long userId = 1L;
-    when(userRepository.findById(userId)).thenReturn(Optional.of(user));
     when(userConverter.convertToUserReadResponse(user)).thenReturn(any());
 
     //When
     userService.getUser(user);
 
     //Then
-    verify(userRepository).findById(userId);
     verify(userConverter).convertToUserReadResponse(user);
   }
 
@@ -138,7 +136,6 @@ class UserServiceTest {
             .password(null)
             .build();
 
-    when(userRepository.findById(userId)).thenReturn(Optional.of(user));
     when(userRepository.existsByNickname(updateRequest.getNickname())).thenReturn(false);
     when(userRepository.save(user)).thenReturn(user);
 
@@ -149,7 +146,6 @@ class UserServiceTest {
     assertThat(user.getNickname(), is(updateRequest.getNickname()));
     assertNotNull(user.getPassword());
 
-    verify(userRepository).findById(userId);
     verify(userRepository).existsByNickname(updateRequest.getNickname());
     verify(userRepository, times(2)).save(user);
   }
@@ -164,7 +160,6 @@ class UserServiceTest {
             .password("new-password")
             .build();
 
-    when(userRepository.findById(userId)).thenReturn(Optional.of(user));
     when(passwordEncoder.encode(updateRequest.getPassword())).thenReturn(newEncodedPassword);
     when(userRepository.save(user)).thenReturn(user);
 
@@ -175,7 +170,6 @@ class UserServiceTest {
     assertNotNull(user.getNickname());
     assertThat(user.getPassword(), is(newEncodedPassword));
 
-    verify(userRepository).findById(userId);
     verify(passwordEncoder).encode(updateRequest.getPassword());
     verify(userRepository, times(2)).save(user);
   }
@@ -190,7 +184,6 @@ class UserServiceTest {
             .password("new-password")
             .build();
 
-    when(userRepository.findById(userId)).thenReturn(Optional.of(user));
     when(userRepository.existsByNickname(updateRequest.getNickname())).thenReturn(false);
     when(passwordEncoder.encode(updateRequest.getPassword())).thenReturn(newEncodedPassword);
     when(userRepository.save(user)).thenReturn(user);
@@ -202,7 +195,6 @@ class UserServiceTest {
     assertThat(user.getNickname(), is(updateRequest.getNickname()));
     assertThat(user.getPassword(), is(newEncodedPassword));
 
-    verify(userRepository).findById(userId);
     verify(userRepository).existsByNickname(updateRequest.getNickname());
     verify(passwordEncoder).encode(updateRequest.getPassword());
     verify(userRepository, times(2)).save(user);
@@ -218,7 +210,6 @@ class UserServiceTest {
             .password("new-password")
             .build();
 
-    when(userRepository.findById(userId)).thenReturn(Optional.of(user));
     when(passwordEncoder.encode(updateRequest.getPassword())).thenReturn(newEncodedPassword);
     when(userRepository.existsByNickname(updateRequest.getNickname())).thenReturn(true);
 
@@ -228,7 +219,6 @@ class UserServiceTest {
     //Then
     assertThat(user.getNickname(), not(updateRequest.getNickname()));
 
-    verify(userRepository).findById(userId);
     verify(passwordEncoder).encode(updateRequest.getPassword());
     verify(userRepository, times(1)).save(user);
   }
@@ -256,7 +246,6 @@ class UserServiceTest {
     roles.add(UserType.ROLE_USER);
     roles.add(UserType.ROLE_BUSINESS);
     //Given
-    given(userRepository.findByEmail(userEmail)).willReturn(Optional.of(user));
     User business = new User(signUpRequest, encodedPassword);
     business.addAuthority(UserType.ROLE_BUSINESS);
     given(userRepository.save(any())).willReturn(business);
@@ -297,14 +286,12 @@ class UserServiceTest {
         .password("$8a$10$ux4JoQBz5AIFWCGh.TdgDuGyOjXpW2oJ3EO7qjbLZ5HTfdynvM34G") //new-password
         .email("user1@test.com")
         .build();
-    when(userRepository.findByEmail(user1.getEmail())).thenReturn(Optional.of(user1));
     when(passwordEncoder.matches(any(), any())).thenReturn(true);
 
     //When
     userService.checkPassword(user, user1.getPassword());
     
     //Then
-    verify(userRepository).findByEmail(user1.getEmail());
     verify(passwordEncoder).matches(any(), any());
   }
 }


### PR DESCRIPTION
## 👩‍💻 요구 사항과 구현 내용
- Controller의 (@AuthUser) User 객체 전달 방법을 수정하였습니다. 
  - user.getId() 로 전달하는 부분을 user 객체를 전달하는 것으로 수정하였습니다. 
- Event 생성 시, Event를 만들 수 있는지 여부에 따라 예외처리 코드를 추가하였습니다. 
## ✅ 피드백 반영사항


## 🤔 PR 포인트 & 궁금한 점
- @AuthUser의 SPEL 을 수정하여 토큰에 맞는 User가 없을 시, null 대신 anonymous 권한을 가진 User 객체를 반환하도록 하여 권한을 통해 서비스 비즈니스 로직을 분기하면 좋을 것 같습니다! 

## 관련 이슈 
TLVB-174