### PR TITLE
[TLVB-133] List 정적 메서드 리팩토링 및 코드리뷰 피드백 적용

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -33,7 +33,7 @@ dependencies {
     implementation 'io.jsonwebtoken:jjwt:0.9.1'
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'
-    implementation 'com.h2database:h2'
+    runtimeOnly 'com.h2database:h2'
     runtimeOnly 'mysql:mysql-connector-java'
     implementation 'org.slf4j:slf4j-api:1.7.32'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'

--- a/src/main/java/kdt/prgrms/kazedon/everevent/service/EventService.java
+++ b/src/main/java/kdt/prgrms/kazedon/everevent/service/EventService.java
@@ -54,10 +54,11 @@ public class EventService {
   public SimpleEventReadResponse getEventsByLocation(String location, User user,
       Pageable pageable) {
     Page<SimpleEvent> simpleEvents;
-    if(user == null)
+    if(user == null) {
       simpleEvents = eventRepository.findByLocation(location, pageable);
-    else
+    } else {
       simpleEvents = eventRepository.findByLocation(location, user.getId(), pageable);
+    }
 
     return eventConverter.convertToSimpleEventReadResponse(simpleEvents);
   }

--- a/src/main/java/kdt/prgrms/kazedon/everevent/service/LikeService.java
+++ b/src/main/java/kdt/prgrms/kazedon/everevent/service/LikeService.java
@@ -12,6 +12,7 @@ import kdt.prgrms.kazedon.everevent.domain.user.repository.UserRepository;
 import kdt.prgrms.kazedon.everevent.exception.like.AlreadyEventLikeException;
 import kdt.prgrms.kazedon.everevent.exception.ErrorMessage;
 import kdt.prgrms.kazedon.everevent.exception.NotFoundException;
+import kdt.prgrms.kazedon.everevent.service.converter.EventLikeConverter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -28,6 +29,8 @@ public class LikeService {
 
   private final EventRepository eventRepository;
 
+  private final EventLikeConverter eventLikeConverter;
+
   @Transactional
   public void addLike(User user, Long eventId) {
     Event event = eventRepository.findById(eventId)
@@ -37,10 +40,7 @@ public class LikeService {
       throw new AlreadyEventLikeException(ErrorMessage.DUPLICATE_EVENT_LIKE, user.getId());
     }
 
-    EventLike eventLike = EventLike.builder()
-                                .user(user)
-                                .event(event)
-                                .build();
+    EventLike eventLike = eventLikeConverter.convertToEventLike(user, event);
     eventLikeRepository.save(eventLike);
     event.plusOneLike();
 
@@ -63,8 +63,6 @@ public class LikeService {
     Page<SimpleEventLike> simpleEventLikes = eventLikeRepository
         .findSimpleLikeByUserId(memberId, pageable);
 
-    return SimpleEventLikeReadResponse.builder()
-        .events(simpleEventLikes)
-        .build();
+    return eventLikeConverter.convertToSimpleEventLikeReadResponse(simpleEventLikes);
   }
 }

--- a/src/main/java/kdt/prgrms/kazedon/everevent/service/converter/EventConverter.java
+++ b/src/main/java/kdt/prgrms/kazedon/everevent/service/converter/EventConverter.java
@@ -1,8 +1,6 @@
 package kdt.prgrms.kazedon.everevent.service.converter;
 
-import java.util.Collections;
-import java.util.List;
-import java.util.Optional;
+import java.util.*;
 import kdt.prgrms.kazedon.everevent.domain.event.Event;
 import kdt.prgrms.kazedon.everevent.domain.event.EventPicture;
 import kdt.prgrms.kazedon.everevent.domain.event.dto.response.DetailEvent;
@@ -63,7 +61,7 @@ public class EventConverter {
             .expiredAt(createRequest.getExpiredAt())
             .description(createRequest.getDescription())
             .maxParticipants(createRequest.getMaxParticipants())
-            .eventPictures(Collections.emptyList())
+            .eventPictures(new ArrayList<>())
             .build();
     }
 

--- a/src/main/java/kdt/prgrms/kazedon/everevent/service/converter/EventConverter.java
+++ b/src/main/java/kdt/prgrms/kazedon/everevent/service/converter/EventConverter.java
@@ -1,6 +1,6 @@
 package kdt.prgrms.kazedon.everevent.service.converter;
 
-import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import kdt.prgrms.kazedon.everevent.domain.event.Event;
@@ -63,7 +63,7 @@ public class EventConverter {
             .expiredAt(createRequest.getExpiredAt())
             .description(createRequest.getDescription())
             .maxParticipants(createRequest.getMaxParticipants())
-            .eventPictures(new ArrayList<>())
+            .eventPictures(Collections.emptyList())
             .build();
     }
 
@@ -92,12 +92,6 @@ public class EventConverter {
         return eventPictures.stream()
             .map(EventPicture::getUrl)
             .findAny();
-    }
-
-    private List<String> getPictureUrls(List<EventPicture> eventPictures) {
-        return eventPictures.stream()
-                .map(EventPicture::getUrl)
-                .toList();
     }
 
     public MarketEventReadResponse convertToMarketEventReadResponse(Page<MarketEvent> marketEvents){

--- a/src/main/java/kdt/prgrms/kazedon/everevent/service/converter/EventLikeConverter.java
+++ b/src/main/java/kdt/prgrms/kazedon/everevent/service/converter/EventLikeConverter.java
@@ -1,0 +1,26 @@
+package kdt.prgrms.kazedon.everevent.service.converter;
+
+import kdt.prgrms.kazedon.everevent.domain.event.Event;
+import kdt.prgrms.kazedon.everevent.domain.like.EventLike;
+import kdt.prgrms.kazedon.everevent.domain.like.dto.response.SimpleEventLike;
+import kdt.prgrms.kazedon.everevent.domain.like.dto.response.SimpleEventLikeReadResponse;
+import kdt.prgrms.kazedon.everevent.domain.user.User;
+import org.springframework.data.domain.Page;
+import org.springframework.stereotype.Component;
+
+@Component
+public class EventLikeConverter {
+
+  public SimpleEventLikeReadResponse convertToSimpleEventLikeReadResponse(Page<SimpleEventLike> simpleEventLikes) {
+    return SimpleEventLikeReadResponse.builder()
+        .events(simpleEventLikes)
+        .build();
+  }
+
+  public EventLike convertToEventLike(User user, Event event) {
+    return EventLike.builder()
+        .user(user)
+        .event(event)
+        .build();
+  }
+}

--- a/src/main/java/kdt/prgrms/kazedon/everevent/service/converter/ReviewConverter.java
+++ b/src/main/java/kdt/prgrms/kazedon/everevent/service/converter/ReviewConverter.java
@@ -55,7 +55,7 @@ public class ReviewConverter {
   }
 
   boolean isBlankPictureUrl(String pictureUrl) {
-    return pictureUrl == null || pictureUrl.isBlank();
+    return (pictureUrl == null) || (pictureUrl.isBlank());
   }
 
 }

--- a/src/main/java/kdt/prgrms/kazedon/everevent/service/converter/ReviewConverter.java
+++ b/src/main/java/kdt/prgrms/kazedon/everevent/service/converter/ReviewConverter.java
@@ -10,7 +10,6 @@ import kdt.prgrms.kazedon.everevent.domain.review.dto.response.SimpleReviewReadR
 import kdt.prgrms.kazedon.everevent.domain.review.dto.response.UserReview;
 import kdt.prgrms.kazedon.everevent.domain.review.dto.response.UserReviewReadResponse;
 import kdt.prgrms.kazedon.everevent.domain.user.User;
-import org.h2.util.StringUtils;
 import org.springframework.data.domain.Page;
 import org.springframework.stereotype.Component;
 
@@ -52,7 +51,11 @@ public class ReviewConverter {
   }
 
   private List<String> convertToPictureUrls(String pictureUrl) {
-    return StringUtils.isNullOrEmpty(pictureUrl) ? Collections.emptyList() : List.of(pictureUrl);
+    return isBlankPictureUrl(pictureUrl) ? Collections.emptyList() : List.of(pictureUrl);
+  }
+
+  boolean isBlankPictureUrl(String pictureUrl) {
+    return pictureUrl == null || pictureUrl.isBlank();
   }
 
 }

--- a/src/main/java/kdt/prgrms/kazedon/everevent/service/converter/ReviewConverter.java
+++ b/src/main/java/kdt/prgrms/kazedon/everevent/service/converter/ReviewConverter.java
@@ -1,6 +1,6 @@
 package kdt.prgrms.kazedon.everevent.service.converter;
 
-import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import kdt.prgrms.kazedon.everevent.domain.event.Event;
 import kdt.prgrms.kazedon.everevent.domain.review.Review;
@@ -52,8 +52,7 @@ public class ReviewConverter {
   }
 
   private List<String> convertToPictureUrls(String pictureUrl) {
-    return StringUtils.isNullOrEmpty(pictureUrl) ? new ArrayList<>()
-        : new ArrayList<>(List.of(pictureUrl));
+    return StringUtils.isNullOrEmpty(pictureUrl) ? Collections.emptyList() : List.of(pictureUrl);
   }
 
 }


### PR DESCRIPTION
## 👩‍💻 요구 사항과 구현 내용
- List 정적 메서드 리팩토링
  - convertToEvent() 의 pictureUrl을 설정하는 부분에서 List 정적 메서드를 사용하지 않은 이유는 이후에 List를 수정을 해야하기 때문입니다.
- if else 괄호 적용
- h2 StirngUtils 제거 
  - 하나의 메서드 사용을 위해 dependency를 추가해야 하는 문제를 지양하기 위해 자체 구현 메서드로 대체 하였습니다. 
- Converter 미적용 부분 제거 

## ✅ 피드백 반영사항

## 🤔 PR 포인트 & 궁금한 점

## 관련 이슈 
TLVB-133