### PR TITLE
[TLVB-218] Main 브랜치에 Merge 전 정적 분석 오류 해결(2)

### DIFF
--- a/scripts/beforeInstall.bash
+++ b/scripts/beforeInstall.bash
@@ -1,8 +1,8 @@
 if [ -d /home/ubuntu/build ]; then
-    rm -rf /home/ubuntu/build
+    sudo rm -rf /home/ubuntu/build
 fi
 
-mkdir -vp /home/ubuntu/build
+sudo mkdir -vp /home/ubuntu/build
 
 docker stop $DOCKER_CONTAINER_NAME
 docker rm $DOCKER_CONTAINER_NAME

--- a/src/main/java/kdt/prgrms/kazedon/everevent/controller/UserController.java
+++ b/src/main/java/kdt/prgrms/kazedon/everevent/controller/UserController.java
@@ -92,9 +92,14 @@ public class UserController {
       @RequestParam String value) {
 
     switch (type) {
-      case EMAIL -> userService.checkEmailDuplicate(value);
-      case NICKNAME -> userService.checkNicknameDuplicate(value);
-      default -> throw new InvalidDuplicationCheckTypeException(ErrorMessage.INVALID_DUPLICATION_CHECK_TYPE, type);
+      case EMAIL:
+        userService.checkEmailDuplicate(value);
+        break;
+      case NICKNAME:
+        userService.checkNicknameDuplicate(value);
+        break;
+      default:
+        throw new InvalidDuplicationCheckTypeException(ErrorMessage.INVALID_DUPLICATION_CHECK_TYPE, type);
     }
 
     return ResponseEntity.ok().build();

--- a/src/main/java/kdt/prgrms/kazedon/everevent/controller/UserController.java
+++ b/src/main/java/kdt/prgrms/kazedon/everevent/controller/UserController.java
@@ -19,6 +19,7 @@ import kdt.prgrms.kazedon.everevent.domain.user.dto.request.UserUpdateRequest;
 import kdt.prgrms.kazedon.everevent.domain.user.dto.response.UserInfoResponse;
 import kdt.prgrms.kazedon.everevent.domain.user.dto.response.UserReadResponse;
 import kdt.prgrms.kazedon.everevent.exception.ErrorMessage;
+import kdt.prgrms.kazedon.everevent.exception.InvalidDuplicationCheckTypeException;
 import kdt.prgrms.kazedon.everevent.exception.UnAuthorizedException;
 import kdt.prgrms.kazedon.everevent.service.EventService;
 import kdt.prgrms.kazedon.everevent.service.FavoriteService;
@@ -49,12 +50,14 @@ import org.springframework.web.bind.annotation.RestController;
 @RequiredArgsConstructor
 public class UserController {
 
+  private static final String EMAIL = "email";
+  private static final String NICKNAME = "nickname";
+
   private final UserService userService;
   private final EventService eventService;
   private final FavoriteService favoriteService;
   private final ReviewService reviewService;
   private final LikeService likeService;
-
   private final JwtAuthenticationProvider jwtAuthenticationProvider;
 
   @PostMapping("/login")
@@ -88,10 +91,10 @@ public class UserController {
   public ResponseEntity<Void> checkDuplicate(@RequestParam String type,
       @RequestParam String value) {
 
-    if(type.equals("eamil")){
-      userService.checkEmailDuplicate(value);
-    }else{
-      userService.checkNicknameDuplicate(value);
+    switch (type) {
+      case EMAIL -> userService.checkEmailDuplicate(value);
+      case NICKNAME -> userService.checkNicknameDuplicate(value);
+      default -> throw new InvalidDuplicationCheckTypeException(ErrorMessage.INVALID_DUPLICATION_CHECK_TYPE, type);
     }
 
     return ResponseEntity.ok().build();

--- a/src/main/java/kdt/prgrms/kazedon/everevent/domain/common/BaseTimeEntity.java
+++ b/src/main/java/kdt/prgrms/kazedon/everevent/domain/common/BaseTimeEntity.java
@@ -1,11 +1,9 @@
 package kdt.prgrms.kazedon.everevent.domain.common;
 
 import java.time.LocalDateTime;
-import java.time.temporal.ChronoUnit;
 import javax.persistence.Column;
 import javax.persistence.EntityListeners;
 import javax.persistence.MappedSuperclass;
-import javax.persistence.PrePersist;
 
 import lombok.Getter;
 import org.springframework.data.annotation.CreatedDate;

--- a/src/main/java/kdt/prgrms/kazedon/everevent/exception/ErrorMessage.java
+++ b/src/main/java/kdt/prgrms/kazedon/everevent/exception/ErrorMessage.java
@@ -27,7 +27,8 @@ public enum ErrorMessage {
   INVALID_TOKEN("{0}는 만료 또는 잘못된 토큰입니다."),
   UNAUTHORIZED_CREATE_EVENT("사용자 {0}은 이벤트를 만들 권한이 없습니다"),
   USER_NOT_PARTICIPATED_EVENT("사용자 {0}는 이벤트 {1}에 참여하지 않았습니다."),
-  UNAUTHORIZED_UPDATE_MARKET("사용자 {0}은 가게를 수정할 권한이 없습니다");
+  UNAUTHORIZED_UPDATE_MARKET("사용자 {0}은 가게를 수정할 권한이 없습니다"),
+  INVALID_DUPLICATION_CHECK_TYPE("사용자의 {0} 중복 체크는 지원하지 않습니다.");
 
   private final String message;
 

--- a/src/main/java/kdt/prgrms/kazedon/everevent/exception/GlobalExceptionHandler.java
+++ b/src/main/java/kdt/prgrms/kazedon/everevent/exception/GlobalExceptionHandler.java
@@ -96,4 +96,10 @@ public class GlobalExceptionHandler {
     return ResponseEntity.badRequest().body(exception.getMessage());
   }
 
+  @ExceptionHandler
+  public ResponseEntity<String> handleInvalidDuplicationCheckType(InvalidDuplicationCheckTypeException exception){
+    log.warn(exception.getMessage());
+    return ResponseEntity.badRequest().body(exception.getMessage());
+  }
+
 }

--- a/src/main/java/kdt/prgrms/kazedon/everevent/exception/GlobalExceptionHandler.java
+++ b/src/main/java/kdt/prgrms/kazedon/everevent/exception/GlobalExceptionHandler.java
@@ -92,13 +92,13 @@ public class GlobalExceptionHandler {
 
   @ExceptionHandler
   public ResponseEntity<String> handleInvalidPassword(InvalidPasswordException exception) {
-    log.warn(exception.getMessage());
+    log.error(exception.getMessage());
     return ResponseEntity.badRequest().body(exception.getMessage());
   }
 
   @ExceptionHandler
   public ResponseEntity<String> handleInvalidDuplicationCheckType(InvalidDuplicationCheckTypeException exception){
-    log.warn(exception.getMessage());
+    log.error(exception.getMessage());
     return ResponseEntity.badRequest().body(exception.getMessage());
   }
 

--- a/src/main/java/kdt/prgrms/kazedon/everevent/exception/InvalidDuplicationCheckTypeException.java
+++ b/src/main/java/kdt/prgrms/kazedon/everevent/exception/InvalidDuplicationCheckTypeException.java
@@ -1,0 +1,10 @@
+package kdt.prgrms.kazedon.everevent.exception;
+
+import java.text.MessageFormat;
+
+public class InvalidDuplicationCheckTypeException extends RuntimeException{
+
+    public InvalidDuplicationCheckTypeException(ErrorMessage errorMessage, String arg) {
+        super(MessageFormat.format(errorMessage.getMessage(), arg));
+    }
+}

--- a/src/test/java/kdt/prgrms/kazedon/everevent/service/UserServiceTest.java
+++ b/src/test/java/kdt/prgrms/kazedon/everevent/service/UserServiceTest.java
@@ -128,7 +128,6 @@ class UserServiceTest {
   @Test
   void updateUserNickname(){
     //Given
-    Long userId = 1L;
     UserUpdateRequest updateRequest = UserUpdateRequest.builder()
             .nickname("update-user-nickname")
             .password(null)
@@ -151,7 +150,6 @@ class UserServiceTest {
   @Test
   void updateUserPassword(){
     //Given
-    Long userId = 1L;
     String newEncodedPassword = "$8a$10$ux4JoQBz5AIFWCGh.TdgDuGyOjXpW2oJ3EO7qjbLZ5HTfdynvM34G";
     UserUpdateRequest updateRequest = UserUpdateRequest.builder()
             .nickname(null)
@@ -175,7 +173,6 @@ class UserServiceTest {
   @Test
   void updateUserNicknameAndPassword(){
     //Given
-    Long userId = 1L;
     String newEncodedPassword = "$8a$10$ux4JoQBz5AIFWCGh.TdgDuGyOjXpW2oJ3EO7qjbLZ5HTfdynvM34G";
     UserUpdateRequest updateRequest = UserUpdateRequest.builder()
             .nickname("new-nickname")
@@ -201,7 +198,6 @@ class UserServiceTest {
   @Test
   void updateUserUsingDuplicatedNickname(){
     //Given
-    Long userId = 1L;
     String newEncodedPassword = "$8a$10$ux4JoQBz5AIFWCGh.TdgDuGyOjXpW2oJ3EO7qjbLZ5HTfdynvM34G";
     UserUpdateRequest updateRequest = UserUpdateRequest.builder()
             .nickname("new-nickname")
@@ -259,7 +255,7 @@ class UserServiceTest {
   }
 
   @Test
-  public void loginTest() {
+  void loginTest() {
     //Given
     LoginRequest loginRequest = LoginRequest.builder().email(userEmail).password(user.getPassword())
         .build();
@@ -279,7 +275,7 @@ class UserServiceTest {
   }
 
   @Test
-  public void checkPasswordTest() {
+  void checkPasswordTest() {
     //Given
     User user1 = User.builder().nickname("user1")
         .location("seoul")


### PR DESCRIPTION
## 👩‍💻 요구 사항과 구현 내용
현재 develop 브랜치에 남아있는 codacy 정적 분석 오류를 추가로 해결했습니다.

## ✅ 피드백 반영사항

## 🤔 PR 포인트 & 궁금한 점
기존 작성된 코드는 사용자 정보 중복 체크 시, Controller에서 중복 체크 타입(email 또는 nickname)을 확인하고 
각 타입에 맞는 Service 메소드를 호출합니다. 

지원되지 않는 타입이 입력되었을 경우에 대한 예외처리가 되어있지 않아, 예외처리 코드를 추가했으며 switch 문으로 변경하여 codacy 문제를 해결했습니다.

## 관련 이슈 
TLVB-218